### PR TITLE
Handle Latin-1 bytes in CMU ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Create or refresh the SQLite database by downloading the source corpora:
 poetry-assistant ingest --database data/poetry.db
 ```
 
-The ingestion command downloads the CMU Pronouncing Dictionary (~3 MB) and the WordNet lexicon (~30 MB via NLTK) and stores structured records in the requested database file. Use `--cmu` to point at a local CMU file, or `--no-wordnet` to skip definition enrichment.
+The CLI defaults to storing data in `poetry_assistant.db` in the current directory. If you choose a different location, such as `data/poetry.db` above, pass the same `--database` flag to subsequent commands. The ingestion command downloads the CMU Pronouncing Dictionary (~3 MB) and the WordNet lexicon (~30 MB via NLTK) and stores structured records in the requested database file. Use `--cmu` to point at a local CMU file, or `--no-wordnet` to skip definition enrichment.
 
 ## Searching the lexicon
 
 ```bash
-poetry-assistant search "AE1 T" --type rhyme --syllables 1 --limit 10
+poetry-assistant search "AE1 T" --type rhyme --syllables 1 --limit 10 --database data/poetry.db
 ```
 
 Key options:
@@ -51,7 +51,7 @@ Results include each word’s pronunciation, stress signature, similarity score 
 ## Rhyming with entire lines
 
 ```bash
-poetry-assistant rhymes-with "I wrote a clever rap" --max-syllables 3
+poetry-assistant rhymes-with "I wrote a clever rap" --max-syllables 3 --database data/poetry.db
 ```
 
 The assistant tokenises the final words of the line, retrieves pronunciations, and returns rhyme suggestions for the last one through N syllables. Near-rhyme parameters (`--max-distance`, `--min-similarity`, `--pos`) mirror the search command.
@@ -59,7 +59,7 @@ The assistant tokenises the final words of the line, retrieves pronunciations, a
 ## Inspecting individual entries
 
 ```bash
-poetry-assistant word serendipity
+poetry-assistant word serendipity --database data/poetry.db
 ```
 
 Displays all pronunciations along with syllable counts, stress patterns, and the associated definitions and synonyms.

--- a/src/poetry_assistant/ingest.py
+++ b/src/poetry_assistant/ingest.py
@@ -74,10 +74,11 @@ def parse_cmudict(path: Path) -> Iterator[Tuple[str, List[str]]]:
     # file without failing while still returning the ASCII word entries
     # exactly as expected.
     with path.open("r", encoding="latin-1") as handle:
-        for line in handle:
+        for raw_line in handle:
+            line = raw_line.strip()
             if not line or line.startswith(";;;"):
                 continue
-            match = pattern.match(line.strip())
+            match = pattern.match(line)
             if not match:
                 continue
             word = match.group("word").lower()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,4 +1,5 @@
-from poetry_assistant.ingest import build_database
+from poetry_assistant.database import PoetryDatabase
+from poetry_assistant.ingest import build_database, ingest_cmudict, parse_cmudict
 
 
 def test_build_database_creates_nested_directory(tmp_path):
@@ -16,3 +17,26 @@ def test_build_database_creates_nested_directory(tmp_path):
     assert db_path.parent.exists()
     assert db_path.exists()
     assert result == db_path
+
+
+def test_cmudict_ingest_tolerates_latin1_bytes(tmp_path):
+    cmu_dict = tmp_path / "cmudict.sample"
+    cmu_dict.write_bytes(
+        b"CAT  K AE1 T\n;;; CAF\xC9 COMMENT\nDOG  D AO1 G\n"
+    )
+
+    entries = list(parse_cmudict(cmu_dict))
+    assert entries == [
+        ("cat", ["K", "AE1", "T"]),
+        ("dog", ["D", "AO1", "G"]),
+    ]
+
+    db_path = tmp_path / "poetry.db"
+    db = PoetryDatabase(db_path)
+    db.initialize()
+    try:
+        ingest_cmudict(db, cmu_dict)
+        pronunciations = db.pronunciations_for_word("cat")
+        assert pronunciations
+    finally:
+        db.close()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -22,7 +22,7 @@ def test_build_database_creates_nested_directory(tmp_path):
 def test_cmudict_ingest_tolerates_latin1_bytes(tmp_path):
     cmu_dict = tmp_path / "cmudict.sample"
     cmu_dict.write_bytes(
-        b"CAT  K AE1 T\n;;; CAF\xC9 COMMENT\nDOG  D AO1 G\n"
+        b"CAT  K AE1 T\n\n;;; CAF\xC9 COMMENT\n  ;;; LEADING SPACE COMMENT\nDOG  D AO1 G\n"
     )
 
     entries = list(parse_cmudict(cmu_dict))


### PR DESCRIPTION
## Summary
- open the CMU dictionary with a Latin-1 reader so stray bytes no longer crash parsing
- add a regression test covering parse_cmudict/ingest_cmudict with a Latin-1 comment line

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd838e0e4083338f71ddb6f0f6faf0