### PR TITLE
Add syllable pattern search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A command line assistant for lyricists, poets, and rappers. The application buil
 
 * **Comprehensive phonetic database** – ingest the [CMU Pronouncing Dictionary](https://github.com/cmusphinx/cmudict) for pronunciations and syllable stress patterns, and enrich entries with definitions, parts of speech, and synonym sets from [WordNet](https://wordnet.princeton.edu/).
 * **Phoneme-aware search** – query by terminal vowel sounds, consonant clusters, combined rhyme keys, full pronunciations, or stress patterns using wildcard or regular-expression style syntax.
+* **Syllable-level pattern search** – describe multi-syllable sequences with onset/nucleus/coda constraints and stress controls for deep rhyme exploration.
 * **Near-rhyme support** – compute phoneme edit distance and similarity scores so that off-rhymes and slant rhymes are surfaced alongside perfect rhymes.
 * **Lexical filters** – limit results to words with specific parts of speech, textual definitions, or synonyms.
 * **Rhyming line assistant** – analyse the last syllables of an input line and propose candidate rhyme words for one to four ending syllables.
@@ -40,13 +41,14 @@ poetry-assistant search "AE1 T" --type rhyme --syllables 1 --limit 10 --database
 Key options:
 
 * `pattern` – phoneme pattern expressed in ARPABET. Use `*` and `?` wildcards or `--regex` for full regular expressions.
-* `--type` – choose `rhyme`, `vowel`, `consonant`, `both`, or `phonemes` depending on the feature you want to match.
+* `--type` – choose `rhyme`, `vowel`, `consonant`, `both`, `phonemes`, or `syllable` depending on the feature you want to match.
 * `--syllables` – how many ending syllables to consider when `--type rhyme`.
 * `--max-distance` / `--min-similarity` – enable near-match scoring by phoneme edit distance.
 * `--stress` – wildcard mask over stress digits (e.g. `1*0` to require stressed then unstressed syllables).
+* `--ignore-syllable-stress` – ignore stress differences when evaluating syllable patterns.
 * `--pos`, `--definition`, `--synonym` – filter by lexical metadata from WordNet.
 
-Results include each word’s pronunciation, stress signature, similarity score (if applicable), and the first matching definition.
+Results include each word’s pronunciation, stress signature, similarity score (if applicable), the syllable range that matched (for syllable searches), and the first matching definition. See `docs/syllable_pattern_guide.md` for the full pattern syntax and examples.
 
 ## Rhyming with entire lines
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ pip install -e ".[cli]"
 
 The optional `tabulate` dependency provides pretty tabular output; without it, search results are emitted as JSON.
 
+## Available CLI commands
+
+The `poetry-assistant` executable exposes the following subcommands:
+
+* `ingest` – download source dictionaries and build or refresh the SQLite database.
+* `search` – query the lexicon for phoneme, syllable, rhyme, or lexical matches.
+* `word` – inspect every stored pronunciation, stress pattern, and definition for a given word.
+* `rhymes-with` – analyse the end of a line and propose rhyme candidates for the trailing syllables.
+
 ## Building the database
 
 Create or refresh the SQLite database by downloading the source corpora:

--- a/README.md
+++ b/README.md
@@ -36,15 +36,23 @@ The `poetry-assistant` executable exposes the following subcommands:
 Create or refresh the SQLite database by downloading the source corpora:
 
 ```bash
-poetry-assistant ingest --database data/poetry.db
+poetry-assistant ingest
 ```
 
-The CLI defaults to storing data in `poetry_assistant.db` in the current directory. If you choose a different location, such as `data/poetry.db` above, pass the same `--database` flag to subsequent commands. The ingestion command downloads the CMU Pronouncing Dictionary (~3 MB) and the WordNet lexicon (~30 MB via NLTK) and stores structured records in the requested database file. Use `--cmu` to point at a local CMU file, or `--no-wordnet` to skip definition enrichment.
+By default the assistant stores its data at
+`$XDG_DATA_HOME/poetry_assistant/poetry_assistant.db`, or
+`~/.local/share/poetry_assistant/poetry_assistant.db` if the XDG environment
+variable is not set. Set the `POETRY_ASSISTANT_DB` environment variable or pass
+`--database /path/to/file.db` to override the location. The ingestion command
+downloads the CMU Pronouncing Dictionary (~3 MB) and the WordNet lexicon (~30
+MB via NLTK) and stores structured records in the requested database file. Use
+`--cmu` to point at a local CMU file, or `--no-wordnet` to skip definition
+enrichment.
 
 ## Searching the lexicon
 
 ```bash
-poetry-assistant search "AE1 T" --type rhyme --syllables 1 --limit 10 --database data/poetry.db
+poetry-assistant search "AE1 T" --type rhyme --syllables 1 --limit 10
 ```
 
 Key options:
@@ -62,7 +70,7 @@ Results include each word’s pronunciation, stress signature, similarity score 
 ## Rhyming with entire lines
 
 ```bash
-poetry-assistant rhymes-with "I wrote a clever rap" --max-syllables 3 --database data/poetry.db
+poetry-assistant rhymes-with "I wrote a clever rap" --max-syllables 3
 ```
 
 The assistant tokenises the final words of the line, retrieves pronunciations, and returns rhyme suggestions for the last one through N syllables. Near-rhyme parameters (`--max-distance`, `--min-similarity`, `--pos`) mirror the search command.
@@ -70,7 +78,7 @@ The assistant tokenises the final words of the line, retrieves pronunciations, a
 ## Inspecting individual entries
 
 ```bash
-poetry-assistant word serendipity --database data/poetry.db
+poetry-assistant word serendipity
 ```
 
 Displays all pronunciations along with syllable counts, stress patterns, and the associated definitions and synonyms.

--- a/docs/multi_syllable_rhyme_plan.md
+++ b/docs/multi_syllable_rhyme_plan.md
@@ -56,23 +56,23 @@ We'll consider two usage modes:
 
 ### Pattern DSL Concepts
 
-We propose a per-syllable pattern grammar, e.g. `ONSET-VOWEL/CODA{STRESS}` or similar. For clarity:
+We propose a per-syllable pattern grammar, e.g. `ONSET-VOWEL[STRESS][/CODA]`:
 
 ```
-SyllablePattern := [Onset] '-' Vowel ['/' Coda] ['{' StressSpec '}']
+SyllablePattern := [Onset] '-' Vowel [StressSpec] ['/' Coda]
 ```
 
 * `Onset`, `Vowel`, `Coda` each accept wildcard characters `*` (any) and `?` (single phoneme) using shell-style semantics.
 * `Onset` and `Coda` components list consonant phonemes separated by spaces (e.g., `K R`), optionally compressed using `.` or `+` to indicate grouping if desirable. We may allow parentheses or just rely on spaces.
-* `Vowel` must contain one vowel phoneme with optional wildcard digits for stress (e.g., `AH*`), or we can separate stress using braces.
+* `Vowel` must contain one vowel phoneme, with stress handled by an optional trailing block such as `[1]`, `[0|2]`, or `{P}` so vowel tokens remain stress-agnostic.
 * `StressSpec` accepts values like `"*"` (don't care), `"S"` (primary stress), `"s"` (secondary), `"U"` (unstressed), or simply digits `0/1/2`.
 
-A multi-syllable pattern is a whitespace-separated list of syllable patterns. Example: `*-AH1/T *-IY0` meaning: first syllable any onset, vowel `AH1`, coda `T`; second syllable any onset, vowel `IY0`, no coda constraint.
+A multi-syllable pattern is a whitespace-separated list of syllable patterns. Example: `*-AH[1]/T *-IY[0]` meaning: first syllable any onset, vowel `AH`, primary stress, coda `T`; second syllable any onset, vowel `IY`, unstressed, no coda constraint.
 
 We'll need to define how to express "no onset" or "no coda". Proposed tokens:
 
 * `Ø` or `.` to represent an empty onset/coda explicitly.
-* Alternatively, treat empty string as valid (two dashes in a row). Example: `-AE1/T` to say no onset.
+* Alternatively, treat empty string as valid (two dashes in a row). Example: `-AE[1]/T` to say no onset.
 
 For planning we can adopt the latter: `-` followed immediately by the vowel pattern indicates empty onset; `*/-` etc. We'll detail this in documentation.
 
@@ -90,7 +90,7 @@ We'll parse the user-provided pattern string into a sequence of `SyllablePattern
 Parsing steps:
 
 1. Tokenize by whitespace to get syllable specs.
-2. For each token, parse subdivisions by `-` and `/` and optional stress braces.
+2. For each token, parse subdivisions by `-` and `/` plus an optional trailing stress block (`[...]` or `{...}`).
 3. Validate that vowels are present and that wildcard digits/stress align with known phoneme sets.
 4. Provide helpful errors for invalid tokens.
 

--- a/docs/multi_syllable_rhyme_plan.md
+++ b/docs/multi_syllable_rhyme_plan.md
@@ -1,0 +1,154 @@
+# Multi-Syllable Rhyme & Pattern Search Plan
+
+## Goals
+
+* Enable searching for pronunciations that match a sequence of `N` syllables, optionally spanning multiple words.
+* Allow per-syllable constraints on:
+  * Initial consonant cluster (onset).
+  * Vowel / vowel cluster (nucleus) including stress marking.
+  * Terminal consonant cluster (coda).
+  * Stressed vs. unstressed syllables.
+* Support wildcards so that any of the above constraints can be ignored ("don't care") or partially constrained.
+* Keep the existing rhyme and phoneme search features working unchanged.
+* Provide a guide and reference material for end users documenting the new feature and the phoneme inventory.
+
+## Guiding Constraints & Questions
+
+* **How do we represent syllables?** We currently store pronunciations as ARPABET phoneme sequences. We need a layer that segments a pronunciation into syllables with onset / nucleus / coda components and stress metadata.
+* **Where does syllable segmentation come from?** CMUdict includes stress digits on vowels but not explicit syllable boundaries. We'll need to infer boundaries algorithmically. We should confirm whether the database already stores syllable counts per pronunciation and whether any syllabified representation exists.
+* **How expressive should the pattern syntax be?** The DSL must let users describe combinations like `* AH1 T` meaning "any onset, vowel AH with primary stress, coda T", or `BR-OW0-*` for onset `BR`, vowel `OW` (unstressed), any coda. We should settle on something that is readable, composable, and relatively straightforward to parse.
+* **How to integrate with the existing search pipeline?** Search currently iterates pronunciations row-by-row and optionally matches patterns using wildcard matching on strings. We'll likely extend this with an additional `pattern_type` (e.g., `"syllable"` or `"syllable_sequence"`) and new helper functions to parse patterns and test matches at the syllable level.
+* **Performance considerations.** Adding syllable segmentation and pattern matching should avoid recomputing heavy work repeatedly. Potential caching strategies include storing syllable breakdowns alongside each pronunciation or memoizing segmentation results within the search process.
+* **Scope boundaries.** We'll focus on offline segmentation of individual pronunciations in Python. Multi-word support can be accomplished by concatenating word pronunciations and then segmenting into syllables.
+
+## Data & Representation Design
+
+### Syllable Model
+
+Represent each syllable as a small dataclass or tuple with:
+
+* `onset`: tuple of consonant phonemes preceding the vowel.
+* `nucleus`: vowel phoneme including stress digit (e.g., `"AE1"`). The base vowel (without stress) can be derived as needed.
+* `coda`: tuple of consonant phonemes following the vowel up to the next syllable boundary.
+* `stress`: derived from the nucleus (0/1/2).
+
+Segmenting a pronunciation of tokens `[phoneme1, phoneme2, ...]` proceeds by scanning for vowels (per `phonetics.is_vowel`). For each vowel, gather preceding consonants since the last vowel as `onset`, assign the vowel to `nucleus`, and gather following consonants until the next vowel or end of pronunciation as `coda`, with the proviso that certain consonant clusters belong to the next syllable onset. We'll need heuristics to split coda vs. onset in clusters.
+
+### Onset/Coda Heuristics
+
+We can implement a simplified syllabification algorithm:
+
+1. Identify indices of vowel phonemes.
+2. For each vowel except the first, there may be consonant(s) between the previous vowel and the current vowel. Use a consonant cluster splitting rule, e.g., **Maximal Onset Principle** guided by a list of permissible onset clusters.
+3. Maintain canonical lists of allowable onsets (single consonants and clusters). The remainder of the cluster attaches to the previous syllable's coda.
+4. The final syllable's trailing consonants become the coda.
+
+We should create reference data sets for allowed onsets and codas based on English phonotactics, perhaps approximated by the set of onsets observed in the CMU dictionary. For planning we can note that we'll generate these lists programmatically during ingestion or by scanning the dataset.
+
+### Multi-Word Handling
+
+When searching across multiple words, we can chain their pronunciations to form a single phoneme sequence, then syllabify that combined sequence. The query pattern of `N` syllables would then be matched against sliding windows within this combined syllable list.
+
+We'll consider two usage modes:
+
+* **Single word search**: default; the database iterates pronunciations for individual words.
+* **Multi-word search**: we join pronunciations from consecutive words (perhaps limited to dictionary entries for phrases) or allow user-provided sequences to be checked for matches. For database-backed search, we can keep iterating word pronunciations but allow pattern lengths greater than the word's syllable count—if the pattern is longer, the word is skipped.
+
+### Pattern DSL Concepts
+
+We propose a per-syllable pattern grammar, e.g. `ONSET-VOWEL/CODA{STRESS}` or similar. For clarity:
+
+```
+SyllablePattern := [Onset] '-' Vowel ['/' Coda] ['{' StressSpec '}']
+```
+
+* `Onset`, `Vowel`, `Coda` each accept wildcard characters `*` (any) and `?` (single phoneme) using shell-style semantics.
+* `Onset` and `Coda` components list consonant phonemes separated by spaces (e.g., `K R`), optionally compressed using `.` or `+` to indicate grouping if desirable. We may allow parentheses or just rely on spaces.
+* `Vowel` must contain one vowel phoneme with optional wildcard digits for stress (e.g., `AH*`), or we can separate stress using braces.
+* `StressSpec` accepts values like `"*"` (don't care), `"S"` (primary stress), `"s"` (secondary), `"U"` (unstressed), or simply digits `0/1/2`.
+
+A multi-syllable pattern is a whitespace-separated list of syllable patterns. Example: `*-AH1/T *-IY0` meaning: first syllable any onset, vowel `AH1`, coda `T`; second syllable any onset, vowel `IY0`, no coda constraint.
+
+We'll need to define how to express "no onset" or "no coda". Proposed tokens:
+
+* `Ø` or `.` to represent an empty onset/coda explicitly.
+* Alternatively, treat empty string as valid (two dashes in a row). Example: `-AE1/T` to say no onset.
+
+For planning we can adopt the latter: `-` followed immediately by the vowel pattern indicates empty onset; `*/-` etc. We'll detail this in documentation.
+
+### Internal Representation of Patterns
+
+We'll parse the user-provided pattern string into a sequence of `SyllablePattern` dataclasses with fields:
+
+* `onset_pattern: WildcardPattern`
+* `vowel_pattern: WildcardPattern`
+* `coda_pattern: WildcardPattern`
+* `stress_constraint: Optional[Set[str]]`
+
+`WildcardPattern` wraps a normalized string pattern plus helper methods for matching tuples of phonemes. We'll treat phoneme clusters as space-joined strings before matching with `fnmatch`. Alternatively, we can compile them into regex objects for flexibility.
+
+Parsing steps:
+
+1. Tokenize by whitespace to get syllable specs.
+2. For each token, parse subdivisions by `-` and `/` and optional stress braces.
+3. Validate that vowels are present and that wildcard digits/stress align with known phoneme sets.
+4. Provide helpful errors for invalid tokens.
+
+### Matching Algorithm
+
+Given a list of syllables for a pronunciation and a pattern sequence:
+
+1. Slide a window of length `len(pattern)` across the syllable list. For each window:
+   * Compare each syllable's onset, vowel, coda, and stress with the corresponding pattern using wildcard matching.
+   * If all syllables in the window match, record the match (the entire word or the matched syllable span).
+2. If multiple windows match within a word, we can either accept the first or return duplicates. We'll likely capture the full word once with metadata about the matching syllable range.
+
+For words with fewer syllables than the pattern length, skip them.
+
+### Database / Storage Considerations
+
+The existing database stores columns `rhyme_key_n`, `terminal_vowels`, `terminal_consonants`, etc. To support the new feature efficiently we might:
+
+* Add a table or JSON blob storing per-pronunciation syllable breakdowns (onset/nucleus/coda/stress). This could be computed during ingestion and cached, avoiding repeated syllabification at query time.
+* Alternatively, perform syllabification on the fly. Initially, to minimize schema changes, we can compute segmentation in Python with memoization per pronunciation string.
+
+For this iteration, we can implement in-memory memoization (e.g., `functools.lru_cache`) on a function that converts a pronunciation string into syllables. If we later need persistence, we can extend the ingest process.
+
+### API & CLI Changes
+
+We'll extend `SearchOptions` with new fields:
+
+* `syllable_pattern: Optional[str]` or reuse `pattern` with `pattern_type="syllable"`.
+* `syllable_mode: Literal["exact", "contains"]` to control sliding-window vs. full-match semantics.
+* Option to ignore stress globally (toggle).
+
+CLI updates should introduce commands/subcommands to specify the new pattern type, possibly using flags like `--syllable-pattern` or `--pattern-type syllable`.
+
+### Testing Strategy
+
+* Unit tests for syllabification: confirm onset/nucleus/coda extraction on sample words (e.g., `"CAT"`, `"STRING"`, `"PHOTOGRAPH"`). Compare against expected stress patterns.
+* Pattern parser tests: ensure valid tokens parse correctly and invalid ones raise descriptive errors.
+* Matching tests: given a known pronunciation, check whether specific patterns match or fail as expected.
+* Integration tests: run search queries over a small fixture database to confirm results include words that match the pattern.
+
+### Documentation Outputs
+
+* **Usage Guide (`docs/syllable_pattern_guide.md`)**: instructions, CLI examples, explanation of pattern syntax and wildcard usage.
+* **Phoneme Reference (`docs/phoneme_reference.txt`)**: list vowels and consonants with their ASCII ARPABET codes, grouped by type, and notes about stress digits.
+
+### Open Questions / TBD
+
+* Should we support optional syllables (e.g., pattern that allows either 2 or 3 syllables)? Initially, no—users supply explicit sequences. We can later add quantifiers.
+* How to expose multi-word results? Perhaps show the word along with syllable indices that matched. We'll need to determine output format.
+* Are we enabling near matches (edit distance) at the syllable level? For now, we keep near-matching semantics on the underlying phoneme text but focus on exact/wildcard matches in the syllable DSL.
+
+### Implementation Phases
+
+1. **Prototype syllable segmentation** function returning structured syllables, with caching.
+2. **Pattern parser** converting user strings into `SyllablePattern` objects.
+3. **Matcher** that tests segmentation windows against the parsed pattern.
+4. **Search integration** via new `pattern_type` branch using the matcher.
+5. **CLI extension** to let users specify the new mode.
+6. **Documentation** as described above.
+7. **Testing** across all new components.
+

--- a/docs/phoneme_reference.txt
+++ b/docs/phoneme_reference.txt
@@ -1,0 +1,60 @@
+ARPABET PHONEME REFERENCE
+=========================
+
+Vowels (append stress digits 0, 1, or 2 when present):
+  AA  ("cot")
+  AE  ("cat")
+  AH  ("cup")
+  AO  ("caught")
+  AW  ("cow")
+  AY  ("kite")
+  EH  ("bet")
+  ER  ("bird")
+  EY  ("bait")
+  IH  ("bit")
+  IY  ("beet")
+  OW  ("boat")
+  OY  ("boy")
+  UH  ("book")
+  UW  ("boot")
+
+Common consonants:
+  B   (voiced bilabial stop)
+  CH  (voiceless postalveolar affricate)
+  D   (voiced alveolar stop)
+  DH  (voiced dental fricative)
+  DX  (voiced flap)
+  F   (voiceless labiodental fricative)
+  G   (voiced velar stop)
+  HH  (voiceless glottal fricative)
+  JH  (voiced postalveolar affricate)
+  K   (voiceless velar stop)
+  L   (alveolar lateral)
+  M   (bilabial nasal)
+  N   (alveolar nasal)
+  NG  (velar nasal)
+  P   (voiceless bilabial stop)
+  R   (alveolar approximant)
+  S   (voiceless alveolar fricative)
+  SH  (voiceless postalveolar fricative)
+  T   (voiceless alveolar stop)
+  TH  (voiceless dental fricative)
+  V   (voiced labiodental fricative)
+  W   (voiced labio-velar approximant)
+  Y   (palatal approximant)
+  Z   (voiced alveolar fricative)
+  ZH  (voiced postalveolar fricative)
+
+Syllabic consonant symbols behave like vowels within some dictionaries but are
+treated as consonants by the search engine:
+  EL  (syllabic L)
+  EM  (syllabic M)
+  EN  (syllabic N)
+  NX  (syllabic NG)
+
+General notes:
+* Vowel phonemes appear with stress digits appended (e.g., `AE1`, `ER0`).
+* Consonant clusters are written by placing phoneme symbols side-by-side
+  separated by spaces (e.g., `S P`, `K R`, `T R`).
+* Wildcards in syllable patterns use the same ASCII symbols (`*`, `?`) as shell
+  globbing.

--- a/docs/syllable_pattern_guide.md
+++ b/docs/syllable_pattern_guide.md
@@ -107,11 +107,17 @@ pronunciation. Combine with `--ignore-syllable-stress` to ignore stress markers.
 poetry-assistant search "[S P]-AY[1] D-ER[0]" --type syllable
 poetry-assistant search "*-AW[1]/*" --type syllable --contains
 poetry-assistant search "D-ER*[1]" --type syllable --contains --ignore-syllable-stress
+poetry-assistant search "*-EH[12]/* *-(AH|ER)[0]/* *-IY[012]/*" --type syllable
 ```
 
 The tabulated output shows the syllable range that satisfied the pattern in the
 `Match` column. Ranges are 1-indexed and inclusive on the right. For example,
 `1-2` means the first two syllables matched.
+
+The final example demonstrates three syllables with wildcard onsets, vowel
+choices, and explicit stress blocks. It matches words such as "heavenly" (`HH
+EH1 V AH0 N L IY0`), "memory" (`M EH1 M ER0 IY0`), and "seventeen" (`S EH1 V
+AH0 N T IY1 N`).
 
 ## Programmatic Usage
 

--- a/docs/syllable_pattern_guide.md
+++ b/docs/syllable_pattern_guide.md
@@ -1,0 +1,133 @@
+# Syllable Pattern Search Guide
+
+This guide explains how to describe multi-syllable rhyme patterns and search for
+matching pronunciations using the poetry assistant tools. The new syllable DSL
+lets you specify onsets, vowels, codas, and stress for each syllable, with
+optional wildcards whenever you do not care about a component.
+
+## Overview
+
+* **Onset** – optional consonant or consonant cluster before the vowel.
+* **Vowel** – one vowel phoneme (ARPABET) including an optional stress digit.
+* **Coda** – optional consonant or consonant cluster after the vowel.
+* **Stress** – optional constraint on the stress of the vowel (primary, secondary,
+  unstressed).
+
+A syllable pattern is written as:
+
+```
+Onset - Vowel [/ Coda] [{Stress}]
+```
+
+Whitespace separates syllables in the full pattern. Use parentheses or square
+brackets when an onset or coda contains spaces (multi-phoneme clusters).
+
+Examples:
+
+* `*-AE1/T{1}` – any onset, vowel `AE1`, coda `T`, primary stress.
+* `-IY0/0` – no onset, vowel `IY0`, empty coda (represented by `0`).
+* `[S P]-AY1/0` – onset `S P`, vowel `AY1`, empty coda.
+
+Combine syllables by placing them next to each other:
+
+```
+[S P]-AY1/0{1} D-ER0/0{0}
+```
+
+This pattern matches the pronunciation of “spider”.
+
+## Wildcards & Empty Components
+
+* `*` and `?` follow shell-style wildcard semantics inside onset, vowel, or coda
+  components. For example, `*-OW?/T` matches any onset, any vowel beginning with
+  `OW` followed by one character (stress digit), and a coda `T`.
+* Leave the onset or coda blank to require it to be empty: `-AE1` or `*-IY0/`
+  (the slash is optional when no coda constraint is desired).
+* Use `0`, `NONE`, or `Ø` after the slash to explicitly require an empty coda, e.g.
+  `*-IY0/0`.
+* Separate multiple phonemes inside onsets or codas with spaces by wrapping the
+  sequence in `[]` or `()`, or use `_`, `.` or `+` as separators. For example,
+  `[K R]-OW1` and `K_R-OW1` both specify an onset of `K R`.
+
+## Token-aware onset and coda constraints
+
+Onset and coda patterns operate on whole phoneme tokens, so wildcards respect
+multi-letter symbols such as `TH`, `CH`, and `SH`.
+
+* `([BD] R)-AW1/N` – matches **brown** and **drown** (onsets `B R` / `D R`) but
+  not **gown** (onset `G`).
+* `*-AW1/N` – the onset wildcard accepts **brown**, **drown**, and **gown** so
+  long as the vowel and coda match.
+* `?-AW1/N` – requires exactly one onset phoneme, matching **gown** while
+  excluding **brown** and **drown** with their two-phoneme clusters.
+* `(* R)-OW1/N` – demands that the final onset consonant be `R`, matching
+  **thrown** (onset `TH R`) while ignoring how many consonants precede it.
+* `?-AA1/(R M)` – accepts any single phoneme onset before the vowel `AA1`, so
+  **charm** (onset `CH`) and **farm** (onset `F`) both qualify.
+
+## Stress Constraints
+
+Stress digits follow CMU dictionary conventions:
+
+* `1` – primary stress.
+* `2` – secondary stress.
+* `0` – unstressed.
+
+Add a stress block with braces to limit stress: `{1}`, `{02}`, `{*}`. The braces
+accept digits directly as well as the shorthand `P` (primary), `S` (secondary),
+and `U` (unstressed). If you do not care about stress, omit the braces or pass
+`--ignore-syllable-stress` when searching.
+
+## CLI Usage
+
+Run the search command with `--type syllable` to activate syllable matching. The
+`--contains` flag allows the pattern to match any consecutive syllables within a
+pronunciation. Combine with `--ignore-syllable-stress` to ignore stress markers.
+
+```bash
+poetry-assistant search "[S P]-AY1/0{1} D-ER0/0" --type syllable
+poetry-assistant search "*-AW1/*" --type syllable --contains
+poetry-assistant search "D-ER*/0{1}" --type syllable --contains --ignore-syllable-stress
+```
+
+The tabulated output shows the syllable range that satisfied the pattern in the
+`Match` column. Ranges are 1-indexed and inclusive on the right. For example,
+`1-2` means the first two syllables matched.
+
+## Programmatic Usage
+
+Use the helper utilities directly from Python:
+
+```python
+from poetry_assistant import parse_syllable_pattern, SearchEngine, SearchOptions
+
+pattern = parse_syllable_pattern("[S P]-AY1/0{1} D-ER0/0")
+options = SearchOptions(pattern_type="syllable", pattern="[S P]-AY1/0{1} D-ER0/0")
+engine = SearchEngine(database)
+results = engine.search(options)
+for match in results:
+    print(match.word, match.matched_syllables)
+```
+
+`parse_syllable_pattern` returns structured pattern objects and `syllabify`
+converts pronunciations into syllables:
+
+```python
+from poetry_assistant import syllabify
+
+syllables = syllabify("S P AY1 D ER0")
+for syllable in syllables:
+    print(syllable.onset_text, syllable.vowel, syllable.coda_text, syllable.stress)
+```
+
+## Tips
+
+* Patterns can span any number of syllables. Combine with `--contains` to search
+  for sub-phrases anywhere in a word or multi-word entry.
+* Leave the pattern empty (omit the argument) to list pronunciations while still
+  benefiting from the `Match` column for reference.
+* When a pattern feels overly restrictive, replace components with `*` to widen
+  the search incrementally.
+* The syllable segmentation uses a maximal onset heuristic guided by common
+  English consonant clusters. Consult the phoneme reference for available onset
+  symbols.

--- a/docs/syllable_pattern_guide.md
+++ b/docs/syllable_pattern_guide.md
@@ -16,7 +16,7 @@ optional wildcards whenever you do not care about a component.
 A syllable pattern is written as:
 
 ```
-Onset - Vowel [/ Coda] [{Stress}]
+Onset - Vowel[Stress] [/ Coda]
 ```
 
 Whitespace separates syllables in the full pattern. Use parentheses or square
@@ -24,14 +24,14 @@ brackets when an onset or coda contains spaces (multi-phoneme clusters).
 
 Examples:
 
-* `*-AE1/T{1}` – any onset, vowel `AE1`, coda `T`, primary stress.
-* `-IY0/0` – no onset, vowel `IY0`, empty coda (represented by `0`).
-* `[S P]-AY1/0` – onset `S P`, vowel `AY1`, empty coda.
+* `*-AE[1]/T` – any onset, vowel `AE`, primary stress, and a `T` coda.
+* `-IY[0]` – no onset, vowel `IY`, unstressed, empty coda (slash omitted).
+* `[S P]-AY[1]` – onset `S P`, vowel `AY`, primary stress, empty coda.
 
 Combine syllables by placing them next to each other:
 
 ```
-[S P]-AY1/0{1} D-ER0/0{0}
+[S P]-AY[1] D-ER[0]
 ```
 
 This pattern matches the pronunciation of “spider”.
@@ -39,15 +39,15 @@ This pattern matches the pronunciation of “spider”.
 ## Wildcards & Empty Components
 
 * `*` and `?` follow shell-style wildcard semantics inside onset, vowel, or coda
-  components. For example, `*-OW?/T` matches any onset, any vowel beginning with
-  `OW` followed by one character (stress digit), and a coda `T`.
-* Leave the onset or coda blank to require it to be empty: `-AE1` or `*-IY0/`
-  (the slash is optional when no coda constraint is desired).
-* Use `0`, `NONE`, or `Ø` after the slash to explicitly require an empty coda, e.g.
-  `*-IY0/0`.
+  components. For example, `*-OW[12]?/T` matches any onset, any vowel beginning
+  with `OW` and ending in stress `1` or `2`, and a `T` coda.
+* Leave the onset or coda blank to require it to be empty: `-AE[1]` or
+  `*-IY[0]/` (the slash is optional when you do not care about the coda).
+* You can still spell out explicit empty markers (`Ø`, `NONE`, `0`) if you
+  prefer, but they are no longer required.
 * Separate multiple phonemes inside onsets or codas with spaces by wrapping the
   sequence in `[]` or `()`, or use `_`, `.` or `+` as separators. For example,
-  `[K R]-OW1` and `K_R-OW1` both specify an onset of `K R`.
+  `[K R]-OW[1]` and `K_R-OW[1]` both specify an onset of `K R`.
 
 ### Vowel alternatives
 
@@ -59,25 +59,28 @@ This pattern matches the pronunciation of “spider”.
 
 Examples:
 
-* `*-(ER|AH)/*{0}` – matches an unstressed syllable with vowel `ER0` or `AH0`.
-* `*-EH/*{1} *-(AH|ER)/*{0} *-AE/P{1}` – matches three-syllable phrases such as
-  **clever rap** (`K_L-EH1/V R-ER0/0 R-AE1/P`) and **mend the gap**
-  (`M-EH1/ND DH-AH0/0 G-AE1/P`).
+* `*-[ER|AH][0]/*` – matches an unstressed syllable with vowel `ER` or `AH`.
+* `*-EH[1]/* *-[AH|ER][0]/* *-AE[1]/P` – matches three-syllable phrases such as
+  **clever rap** (`K_L-EH[1]/V R-ER[0]/Ø R-AE[1]/P`) and **mend the gap**
+  (`M-EH[1]/ND DH-AH[0]/Ø G-AE[1]/P`).
+* `([B|K] R)-[AA|AE][0|1]/[P|T]` – accepts clusters like **brat**, **crap**,
+  **crop**, or the surname **Kratt** by allowing either `B R` or `K R` onsets,
+  vowels `AA` or `AE`, stress `0` or `1`, and codas `P` or `T`.
 
 ## Token-aware onset and coda constraints
 
 Onset and coda patterns operate on whole phoneme tokens, so wildcards respect
 multi-letter symbols such as `TH`, `CH`, and `SH`.
 
-* `([BD] R)-AW1/N` – matches **brown** and **drown** (onsets `B R` / `D R`) but
+* `([BD] R)-AW[1]/N` – matches **brown** and **drown** (onsets `B R` / `D R`) but
   not **gown** (onset `G`).
-* `*-AW1/N` – the onset wildcard accepts **brown**, **drown**, and **gown** so
+* `*-AW[1]/N` – the onset wildcard accepts **brown**, **drown**, and **gown** so
   long as the vowel and coda match.
-* `?-AW1/N` – requires exactly one onset phoneme, matching **gown** while
+* `?-AW[1]/N` – requires exactly one onset phoneme, matching **gown** while
   excluding **brown** and **drown** with their two-phoneme clusters.
-* `(* R)-OW1/N` – demands that the final onset consonant be `R`, matching
+* `(* R)-OW[1]/N` – demands that the final onset consonant be `R`, matching
   **thrown** (onset `TH R`) while ignoring how many consonants precede it.
-* `?-AA1/(R M)` – accepts any single phoneme onset before the vowel `AA1`, so
+* `?-AA[1]/(R M)` – accepts any single phoneme onset before the vowel `AA`, so
   **charm** (onset `CH`) and **farm** (onset `F`) both qualify.
 
 ## Stress Constraints
@@ -88,10 +91,11 @@ Stress digits follow CMU dictionary conventions:
 * `2` – secondary stress.
 * `0` – unstressed.
 
-Add a stress block with braces to limit stress: `{1}`, `{02}`, `{*}`. The braces
-accept digits directly as well as the shorthand `P` (primary), `S` (secondary),
-and `U` (unstressed). If you do not care about stress, omit the braces or pass
-`--ignore-syllable-stress` when searching.
+Add a trailing stress block with brackets (e.g., `[1]`, `[0|2]`) or braces if
+you prefer (`{1}`, `{0|2}`). The block accepts digits directly as well as the
+shorthand `P` (primary), `S` (secondary), and `U` (unstressed). If you do not
+care about stress, omit the block entirely or pass `--ignore-syllable-stress`
+when searching.
 
 ## CLI Usage
 
@@ -100,9 +104,9 @@ Run the search command with `--type syllable` to activate syllable matching. The
 pronunciation. Combine with `--ignore-syllable-stress` to ignore stress markers.
 
 ```bash
-poetry-assistant search "[S P]-AY1/0{1} D-ER0/0" --type syllable
-poetry-assistant search "*-AW1/*" --type syllable --contains
-poetry-assistant search "D-ER*/0{1}" --type syllable --contains --ignore-syllable-stress
+poetry-assistant search "[S P]-AY[1] D-ER[0]" --type syllable
+poetry-assistant search "*-AW[1]/*" --type syllable --contains
+poetry-assistant search "D-ER*[1]" --type syllable --contains --ignore-syllable-stress
 ```
 
 The tabulated output shows the syllable range that satisfied the pattern in the
@@ -116,8 +120,8 @@ Use the helper utilities directly from Python:
 ```python
 from poetry_assistant import parse_syllable_pattern, SearchEngine, SearchOptions
 
-pattern = parse_syllable_pattern("[S P]-AY1/0{1} D-ER0/0")
-options = SearchOptions(pattern_type="syllable", pattern="[S P]-AY1/0{1} D-ER0/0")
+pattern = parse_syllable_pattern("[S P]-AY[1] D-ER[0]")
+options = SearchOptions(pattern_type="syllable", pattern="[S P]-AY[1] D-ER[0]")
 engine = SearchEngine(database)
 results = engine.search(options)
 for match in results:
@@ -129,10 +133,13 @@ converts pronunciations into syllables:
 
 ```python
 from poetry_assistant import syllabify
+from poetry_assistant.phonetics import strip_stress
 
 syllables = syllabify("S P AY1 D ER0")
 for syllable in syllables:
-    print(f"{syllable.onset_text}-{syllable.vowel}/{syllable.coda_text}", syllable.stress)
+    onset = syllable.onset_text or "-"
+    coda = syllable.coda_text
+    print(f"{onset}-{strip_stress(syllable.vowel)}[{syllable.stress}]/{coda}")
 ```
 
 ## Tips

--- a/docs/syllable_pattern_guide.md
+++ b/docs/syllable_pattern_guide.md
@@ -49,6 +49,21 @@ This pattern matches the pronunciation of “spider”.
   sequence in `[]` or `()`, or use `_`, `.` or `+` as separators. For example,
   `[K R]-OW1` and `K_R-OW1` both specify an onset of `K R`.
 
+### Vowel alternatives
+
+* Provide multiple vowel options by separating them with `|`, commas, or
+  whitespace inside brackets/parentheses. Each option may include wildcards.
+* When you omit a stress digit (e.g., `ER` instead of `ER0`), the pattern will
+  match any vowel sharing that base phoneme. Combine with stress braces to limit
+  the allowed stress levels.
+
+Examples:
+
+* `*-(ER|AH)/*{0}` – matches an unstressed syllable with vowel `ER0` or `AH0`.
+* `*-EH/*{1} *-(AH|ER)/*{0} *-AE/P{1}` – matches three-syllable phrases such as
+  **clever rap** (`K L EH1 · V ER0 · R AE1 P`) and **mend the gap**
+  (`M EH1 N D · DH AH0 · G AE1 P`).
+
 ## Token-aware onset and coda constraints
 
 Onset and coda patterns operate on whole phoneme tokens, so wildcards respect

--- a/docs/syllable_pattern_guide.md
+++ b/docs/syllable_pattern_guide.md
@@ -61,8 +61,8 @@ Examples:
 
 * `*-(ER|AH)/*{0}` – matches an unstressed syllable with vowel `ER0` or `AH0`.
 * `*-EH/*{1} *-(AH|ER)/*{0} *-AE/P{1}` – matches three-syllable phrases such as
-  **clever rap** (`K L EH1 · V ER0 · R AE1 P`) and **mend the gap**
-  (`M EH1 N D · DH AH0 · G AE1 P`).
+  **clever rap** (`K_L-EH1/V R-ER0/0 R-AE1/P`) and **mend the gap**
+  (`M-EH1/ND DH-AH0/0 G-AE1/P`).
 
 ## Token-aware onset and coda constraints
 
@@ -132,7 +132,7 @@ from poetry_assistant import syllabify
 
 syllables = syllabify("S P AY1 D ER0")
 for syllable in syllables:
-    print(syllable.onset_text, syllable.vowel, syllable.coda_text, syllable.stress)
+    print(f"{syllable.onset_text}-{syllable.vowel}/{syllable.coda_text}", syllable.stress)
 ```
 
 ## Tips

--- a/docs/tasklist.md
+++ b/docs/tasklist.md
@@ -1,0 +1,25 @@
+# Task List
+
+This backlog captures upcoming enhancements requested for the poetry assistant. Each task should receive a design spike and implementation plan before coding begins.
+
+## Data Enrichment
+
+- [ ] **Attach relative word frequencies to the lexicon.** Source corpus-based frequency counts (e.g., SUBTLEX, Google N-grams) during database ingestion, normalize them, and store alongside each pronunciation to let search rank common words more highly than rare ones.
+- [ ] **Record part-of-speech metadata.** Incorporate POS tags for each word/pronunciation variant so queries can filter by grammatical role. Decide how to handle words with multiple parts of speech and whether to expose priorities.
+- [ ] **Build synonym families.** Integrate a thesaurus dataset to cluster words into synonym sets. Provide identifiers so the search engine can expand queries or group results by semantic family.
+
+## Search Engine Enhancements
+
+- [ ] **Expose part-of-speech filters in search options.** Extend the API and CLI so users can restrict results to specific POS categories, using the metadata added above.
+- [ ] **Support configurable multi-word/phrase composition.** Allow patterns to match sequences that span multiple dictionary entries while giving users strict controls (e.g., maximum span length, explicit enable flags) to avoid combinatorial explosions.
+- [ ] **Introduce syllable-level fuzzy matching.** Implement an edit-distance style metric that scores onset, vowel, and coda differences equally at one-third apiece. Provide thresholds or top-N selection so users can request near matches instead of exact token matches.
+
+## Performance & Scalability
+
+- [ ] **Optimize large-scale searches.** Profile the new syllable-matching and combination logic on the full lexicon, add indexes or caching as needed, and ensure latency remains acceptable even when many pronunciations satisfy a loose pattern.
+- [ ] **Provide configuration for resource-heavy features.** Offer toggles for expensive operations (e.g., enabling fuzzy search or multi-word composition) and sensible defaults that keep the search responsive in production settings.
+
+## Documentation & UX
+
+- [ ] **Update guides once features land.** Expand the syllable pattern guide and CLI docs to describe frequency-aware ranking, POS filtering, synonym usage, and fuzzy match semantics with real-word examples.
+- [ ] **Document data sources and refresh cadence.** Record where frequency, POS, and thesaurus data originate, plus how often they should be refreshed to keep the database current.

--- a/src/poetry_assistant/__init__.py
+++ b/src/poetry_assistant/__init__.py
@@ -1,7 +1,15 @@
 """Poetry assistant package for rhyme and phonetic exploration."""
 
 from .database import PoetryDatabase
-from .search import SearchEngine
 from .rhymes import RhymeAssistant
+from .search import SearchEngine, SearchOptions
+from .syllables import parse_syllable_pattern, syllabify
 
-__all__ = ["PoetryDatabase", "SearchEngine", "RhymeAssistant"]
+__all__ = [
+    "PoetryDatabase",
+    "SearchEngine",
+    "SearchOptions",
+    "RhymeAssistant",
+    "parse_syllable_pattern",
+    "syllabify",
+]

--- a/src/poetry_assistant/models.py
+++ b/src/poetry_assistant/models.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 
 @dataclass
@@ -27,4 +27,5 @@ class SearchResult:
     terminal_consonants: str
     rhyme_key: Optional[str]
     definitions: List[Definition] = field(default_factory=list)
+    matched_syllables: Optional[Tuple[int, int]] = None
 

--- a/src/poetry_assistant/syllables.py
+++ b/src/poetry_assistant/syllables.py
@@ -1,0 +1,501 @@
+"""Syllable segmentation and pattern matching utilities."""
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterator, List, Optional, Sequence, Tuple
+
+from .phonetics import is_vowel, strip_stress, tokens
+
+# ---------------------------------------------------------------------------
+# Syllable representation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Syllable:
+    """Structured view of a syllable within a pronunciation."""
+
+    onset: Tuple[str, ...]
+    nucleus: str
+    coda: Tuple[str, ...]
+    stress: str
+
+    @property
+    def onset_text(self) -> str:
+        return " ".join(self.onset)
+
+    @property
+    def coda_text(self) -> str:
+        return " ".join(self.coda)
+
+    @property
+    def vowel(self) -> str:
+        return self.nucleus
+
+    @property
+    def vowel_base(self) -> str:
+        return strip_stress(self.nucleus)
+
+
+# ---------------------------------------------------------------------------
+# Syllable segmentation
+# ---------------------------------------------------------------------------
+
+_SINGLE_ONSETS = {
+    "B",
+    "CH",
+    "D",
+    "DH",
+    "F",
+    "G",
+    "HH",
+    "JH",
+    "K",
+    "L",
+    "M",
+    "N",
+    "P",
+    "R",
+    "S",
+    "SH",
+    "T",
+    "TH",
+    "V",
+    "W",
+    "Y",
+    "Z",
+    "ZH",
+    "NG",
+}
+
+_CLUSTER_ONSETS = {
+    ("B", "L"),
+    ("B", "R"),
+    ("B", "W"),
+    ("CH", "R"),
+    ("D", "R"),
+    ("D", "W"),
+    ("F", "L"),
+    ("F", "R"),
+    ("G", "L"),
+    ("G", "R"),
+    ("G", "W"),
+    ("HH", "Y"),
+    ("K", "L"),
+    ("K", "R"),
+    ("K", "W"),
+    ("P", "L"),
+    ("P", "R"),
+    ("P", "W"),
+    ("S", "K"),
+    ("S", "L"),
+    ("S", "M"),
+    ("S", "N"),
+    ("S", "P"),
+    ("S", "T"),
+    ("S", "W"),
+    ("SH", "R"),
+    ("T", "R"),
+    ("T", "W"),
+    ("TH", "R"),
+    ("TH", "W"),
+    ("V", "L"),
+    ("V", "R"),
+    ("Z", "L"),
+    ("Z", "R"),
+    ("ZH", "R"),
+    ("S", "P", "L"),
+    ("S", "P", "R"),
+    ("S", "T", "L"),
+    ("S", "T", "R"),
+    ("S", "K", "L"),
+    ("S", "K", "R"),
+    ("S", "K", "W"),
+}
+
+_ALLOWED_ONSETS: set[Tuple[str, ...]] = {(c,) for c in _SINGLE_ONSETS}
+_ALLOWED_ONSETS.update(_CLUSTER_ONSETS)
+
+
+def syllabify(pronunciation: Sequence[str] | str) -> List[Syllable]:
+    """Split a pronunciation into syllables."""
+
+    if isinstance(pronunciation, str):
+        phonemes = tuple(tokens(pronunciation))
+    else:
+        phonemes = tuple(pronunciation)
+    return list(_syllabify_cached(phonemes))
+
+
+@lru_cache(maxsize=8192)
+def _syllabify_cached(phonemes: Tuple[str, ...]) -> Tuple[Syllable, ...]:
+    syllables: List[Syllable] = []
+    current_onset: List[str] = []
+    i = 0
+    length = len(phonemes)
+    while i < length:
+        phoneme = phonemes[i]
+        if is_vowel(phoneme):
+            nucleus = phoneme
+            stress = phoneme[-1] if phoneme[-1].isdigit() else "0"
+            # gather consonants until next vowel
+            j = i + 1
+            buffer: List[str] = []
+            while j < length and not is_vowel(phonemes[j]):
+                buffer.append(phonemes[j])
+                j += 1
+            next_vowel_exists = j < length
+            coda, next_onset = _split_cluster(buffer, next_vowel_exists)
+            syllables.append(
+                Syllable(onset=tuple(current_onset), nucleus=nucleus, coda=tuple(coda), stress=stress)
+            )
+            current_onset = next_onset
+            i = j
+        else:
+            current_onset.append(phoneme)
+            i += 1
+    # Any trailing onset consonants become part of the last coda
+    if current_onset and syllables:
+        last = syllables[-1]
+        merged_coda = last.coda + tuple(current_onset)
+        syllables[-1] = Syllable(onset=last.onset, nucleus=last.nucleus, coda=merged_coda, stress=last.stress)
+    return tuple(syllables)
+
+
+def _split_cluster(cluster: List[str], allow_onset: bool) -> Tuple[List[str], List[str]]:
+    if not cluster:
+        return [], []
+    if not allow_onset:
+        return list(cluster), []
+    for index in range(len(cluster)):
+        suffix = tuple(cluster[index:])
+        if suffix in _ALLOWED_ONSETS:
+            return cluster[:index], list(suffix)
+    # default: keep final consonant as onset of next syllable
+    return cluster[:-1], [cluster[-1]]
+
+
+# ---------------------------------------------------------------------------
+# Pattern parsing and matching
+# ---------------------------------------------------------------------------
+
+_EMPTY_MARKERS = {"", "Ø", "ø", "0", "NONE", "none", "NULL", "null"}
+
+
+@dataclass(frozen=True)
+class _TokenPattern:
+    kind: str
+    values: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ComponentPattern:
+    tokens: Optional[Tuple[_TokenPattern, ...]] = None
+    require_empty: bool = False
+
+    def matches(self, cluster: Sequence[str]) -> bool:
+        if self.require_empty:
+            return len(cluster) == 0
+        if self.tokens is None:
+            return True
+        return _match_token_pattern(self.tokens, tuple(cluster))
+
+
+@dataclass(frozen=True)
+class SyllablePattern:
+    onset: ComponentPattern
+    vowel: str
+    coda: ComponentPattern
+    stress: Optional[set[str]] = None
+
+    def matches(self, syllable: Syllable, *, ignore_stress: bool = False) -> bool:
+        if not self.onset.matches(syllable.onset):
+            return False
+        if not fnmatch.fnmatchcase(syllable.vowel, self.vowel):
+            return False
+        if not self.coda.matches(syllable.coda):
+            return False
+        if ignore_stress or self.stress is None:
+            return True
+        return syllable.stress in self.stress
+
+
+def parse_syllable_pattern(pattern: str) -> List[SyllablePattern]:
+    """Parse a multi-syllable pattern string."""
+
+    tokens = _tokenize(pattern)
+    syllables: List[SyllablePattern] = []
+    for token in tokens:
+        stress_values: Optional[set[str]] = None
+        core = token.strip()
+        if not core:
+            raise ValueError("Empty syllable pattern segment")
+        if "{" in core:
+            core, stress_values = _extract_stress(core)
+        if "-" not in core:
+            raise ValueError(f"Invalid syllable pattern '{token}': missing '-' separator")
+        onset_text, remainder = core.split("-", 1)
+        onset = _parse_component(onset_text, allow_wildcard=True)
+        coda = ComponentPattern(tokens=None, require_empty=False)
+        vowel_text = remainder
+        if "/" in remainder:
+            vowel_text, coda_text = remainder.split("/", 1)
+            coda = _parse_component(coda_text, allow_wildcard=True)
+        vowel_text = vowel_text.strip()
+        if not vowel_text:
+            raise ValueError(f"Invalid syllable pattern '{token}': missing vowel specification")
+        syllables.append(
+            SyllablePattern(
+                onset=onset,
+                vowel=_normalize_component_text(vowel_text),
+                coda=coda,
+                stress=stress_values,
+            )
+        )
+    return syllables
+
+
+def find_syllable_matches(
+    syllables: Sequence[Syllable],
+    pattern: Sequence[SyllablePattern],
+    *,
+    contains: bool = False,
+    ignore_stress: bool = False,
+) -> List[Tuple[int, int]]:
+    """Return the start/end indices of matches for ``pattern`` within ``syllables``."""
+
+    if not pattern:
+        return [(0, 0)] if not syllables else [(0, len(syllables))]
+    required = len(pattern)
+    if required > len(syllables):
+        return []
+    matches: List[Tuple[int, int]] = []
+    if not contains and required != len(syllables):
+        return []
+    start_indices: Iterator[int]
+    if contains:
+        start_indices = range(0, len(syllables) - required + 1)
+    else:
+        start_indices = iter((0,))
+    for start in start_indices:
+        window = syllables[start : start + required]
+        if all(p.matches(s, ignore_stress=ignore_stress) for p, s in zip(pattern, window)):
+            matches.append((start, start + required))
+    return matches
+
+
+def matches_syllable_pattern(
+    syllables: Sequence[Syllable],
+    pattern: Sequence[SyllablePattern],
+    *,
+    contains: bool = False,
+    ignore_stress: bool = False,
+) -> bool:
+    """Return ``True`` if ``pattern`` matches ``syllables``."""
+
+    return bool(find_syllable_matches(syllables, pattern, contains=contains, ignore_stress=ignore_stress))
+
+
+def _tokenize(pattern: str) -> List[str]:
+    tokens: List[str] = []
+    current: List[str] = []
+    depth = 0
+    for char in pattern.strip():
+        if char in "([":
+            depth += 1
+        elif char in ")]":
+            if depth == 0:
+                raise ValueError(f"Unmatched closing bracket in pattern '{pattern}'")
+            depth -= 1
+        if char.isspace() and depth == 0:
+            if current:
+                tokens.append("".join(current))
+                current = []
+        else:
+            current.append(char)
+    if current:
+        tokens.append("".join(current))
+    if depth != 0:
+        raise ValueError(f"Unmatched opening bracket in pattern '{pattern}'")
+    return tokens
+
+
+def _extract_stress(token: str) -> Tuple[str, Optional[set[str]]]:
+    if token.count("{") != token.count("}"):
+        raise ValueError(f"Mismatched braces in pattern '{token}'")
+    start = token.index("{")
+    end = token.index("}", start)
+    stress_spec = token[start + 1 : end].strip()
+    remaining = (token[:start] + token[end + 1 :]).strip()
+    if not stress_spec or stress_spec == "*":
+        return remaining, None
+    allowed: set[str] = set()
+    for symbol in stress_spec.replace(",", "").replace("|", ""):
+        if symbol in "012":
+            allowed.add(symbol)
+        elif symbol in "Pp":
+            allowed.add("1")
+        elif symbol in "Ss":
+            allowed.add("2")
+        elif symbol in "Uu":
+            allowed.add("0")
+        elif symbol.isspace():
+            continue
+        else:
+            raise ValueError(f"Unknown stress marker '{symbol}' in pattern '{token}'")
+    if not allowed:
+        return remaining, None
+    return remaining, allowed
+
+
+def _parse_component(text: str, allow_wildcard: bool) -> ComponentPattern:
+    raw = text.strip()
+    if not raw:
+        return ComponentPattern(tokens=None, require_empty=True)
+    cleaned = _strip_brackets(raw)
+    normalized = _normalize_component_text(cleaned)
+    if normalized.upper() in _EMPTY_MARKERS:
+        return ComponentPattern(tokens=None, require_empty=True)
+    if not allow_wildcard and normalized == "*":
+        raise ValueError("'*' is not allowed for onset components; use explicit phonemes or omit the onset")
+    token_pattern = _compile_component_pattern(normalized)
+    return ComponentPattern(tokens=token_pattern)
+
+
+def _strip_brackets(text: str) -> str:
+    stripped = text.strip()
+    if (stripped.startswith("[") and stripped.endswith("]")) or (
+        stripped.startswith("(") and stripped.endswith(")")
+    ):
+        return stripped[1:-1].strip()
+    return stripped
+
+
+def _normalize_component_text(text: str) -> str:
+    cleaned = text.replace("_", " ").replace(".", " ").replace("+", " ")
+    parts = cleaned.strip().split()
+    return " ".join(parts)
+
+
+def _compile_component_pattern(text: str) -> Tuple[_TokenPattern, ...]:
+    tokens = _split_component_tokens(text)
+    if not tokens:
+        return tuple()
+    compiled: List[_TokenPattern] = []
+    for token in tokens:
+        if token == "*":
+            compiled.append(_TokenPattern("star"))
+        elif token == "?":
+            compiled.append(_TokenPattern("any"))
+        elif token.startswith("[") and token.endswith("]"):
+            choices = _parse_choice_block(token)
+            compiled.append(_TokenPattern("set", choices))
+        else:
+            compiled.append(_TokenPattern("literal", (token,)))
+    return tuple(compiled)
+
+
+def _split_component_tokens(text: str) -> List[str]:
+    tokens: List[str] = []
+    current: List[str] = []
+    depth = 0
+    for char in text:
+        if char == "[":
+            depth += 1
+            current.append(char)
+        elif char == "]":
+            if depth == 0:
+                raise ValueError(f"Unmatched closing bracket in component '{text}'")
+            depth -= 1
+            current.append(char)
+        elif char.isspace() and depth == 0:
+            if current:
+                tokens.append("".join(current))
+                current = []
+        else:
+            current.append(char)
+    if depth != 0:
+        raise ValueError(f"Unmatched opening bracket in component '{text}'")
+    if current:
+        tokens.append("".join(current))
+    return [token for token in (token.strip() for token in tokens) if token]
+
+
+def _parse_choice_block(token: str) -> Tuple[str, ...]:
+    inner = token[1:-1].strip()
+    if not inner:
+        raise ValueError("Empty choice block '[]' is not allowed in onset or coda patterns")
+    pieces: List[str] = []
+    current: List[str] = []
+    for char in inner:
+        if char in {" ", "\t", "\n", "\r", ",", "|"}:
+            if current:
+                pieces.append("".join(current))
+                current = []
+        elif char in {"_", ".", "+"}:
+            if current:
+                pieces.append("".join(current))
+                current = []
+        else:
+            current.append(char)
+    if current:
+        pieces.append("".join(current))
+    pieces = [piece for piece in (piece.strip() for piece in pieces) if piece]
+    if pieces:
+        if len(pieces) == 1 and pieces[0] == inner:
+            # no explicit separators; treat contiguous uppercase symbols as individual consonants when possible
+            if inner.isalpha() and inner.isupper():
+                letters: List[str] = []
+                for char in inner:
+                    symbol = char
+                    if symbol in _SINGLE_ONSETS:
+                        letters.append(symbol)
+                    else:
+                        return (inner,)
+                if letters:
+                    return tuple(letters)
+        return tuple(pieces)
+    # default fallback: treat each uppercase consonant individually when possible
+    if inner.isalpha() and inner.isupper():
+        letters = [char for char in inner if char in _SINGLE_ONSETS]
+        if letters and len(letters) == len(inner):
+            return tuple(letters)
+    return (inner,)
+
+
+def _match_token_pattern(pattern: Sequence[_TokenPattern], cluster: Sequence[str]) -> bool:
+    def _match(pi: int, ci: int) -> bool:
+        while pi < len(pattern):
+            part = pattern[pi]
+            if part.kind == "star":
+                # Collapse consecutive stars for efficiency
+                while pi + 1 < len(pattern) and pattern[pi + 1].kind == "star":
+                    pi += 1
+                next_index = pi + 1
+                if next_index == len(pattern):
+                    return True
+                for skip in range(ci, len(cluster) + 1):
+                    if _match(next_index, skip):
+                        return True
+                return False
+            if ci >= len(cluster):
+                return False
+            token = cluster[ci]
+            if part.kind == "literal":
+                if token != part.values[0]:
+                    return False
+            elif part.kind == "any":
+                pass
+            elif part.kind == "set":
+                if token not in part.values:
+                    return False
+            else:
+                raise ValueError(f"Unknown token pattern kind '{part.kind}'")
+            pi += 1
+            ci += 1
+        return ci == len(cluster)
+
+    return _match(0, 0)
+

--- a/tests/_bootstrap.py
+++ b/tests/_bootstrap.py
@@ -1,0 +1,13 @@
+"""Test helper to ensure the project package is importable when run as a script."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+
+for path in (PROJECT_ROOT, SRC_PATH):
+    str_path = str(path)
+    if str_path not in sys.path:
+        sys.path.insert(0, str_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,18 @@ def sample_db(tmp_path):
             "pronunciations": ["B AE1 T AH0 L"],
             "definitions": [("noun", "a fight between opposing forces", ["combat"])],
         },
+        "about": {
+            "pronunciations": ["AH0 B AW1 T"],
+            "definitions": [("preposition", "on the subject of", ["regarding"])],
+        },
+        "spider": {
+            "pronunciations": ["S P AY1 D ER0"],
+            "definitions": [("noun", "an eight-legged arachnid", ["arachnid"])],
+        },
+        "amazing": {
+            "pronunciations": ["AH0 M EY1 Z IH0 NG"],
+            "definitions": [("adjective", "causing great surprise", ["astonishing"])],
+        },
     }
 
     for word, details in data.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
+import _bootstrap  # noqa: F401
 import pytest
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "src"))
 
 from poetry_assistant.database import PoetryDatabase
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,3 +26,37 @@ def test_ingest_accepts_database_option_in_any_position(monkeypatch, tmp_path):
 
     cli.main(["--database", str(db_path), "ingest"])
     assert calls and calls[-1] == db_path
+
+
+def test_default_database_path_prefers_env_override(monkeypatch, tmp_path):
+    env_path = tmp_path / "custom.db"
+    monkeypatch.setenv("POETRY_ASSISTANT_DB", str(env_path))
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    resolved = cli._default_database_path()
+    assert resolved == env_path
+
+
+def test_default_database_path_prefers_existing_files(monkeypatch, tmp_path):
+    monkeypatch.delenv("POETRY_ASSISTANT_DB", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    home_dir = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home_dir))
+    monkeypatch.chdir(tmp_path)
+
+    local_db = tmp_path / "poetry_assistant.db"
+    local_db.write_text("")
+
+    resolved = cli._default_database_path()
+    assert resolved == local_db
+
+
+def test_default_database_path_uses_xdg_data_home(monkeypatch, tmp_path):
+    monkeypatch.delenv("POETRY_ASSISTANT_DB", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    home_dir = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home_dir))
+
+    resolved = cli._default_database_path()
+    expected = tmp_path / "xdg" / "poetry_assistant" / "poetry_assistant.db"
+    assert resolved == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import _bootstrap  # noqa: F401
+
 from poetry_assistant import cli
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,3 +1,5 @@
+import _bootstrap  # noqa: F401
+
 from poetry_assistant.database import PoetryDatabase
 from poetry_assistant.ingest import build_database, ingest_cmudict, parse_cmudict
 

--- a/tests/test_phonetics.py
+++ b/tests/test_phonetics.py
@@ -1,5 +1,7 @@
 import pytest
 
+import _bootstrap  # noqa: F401
+
 from poetry_assistant.phonetics import Pronunciation, levenshtein_distance, similarity
 
 

--- a/tests/test_rhymes.py
+++ b/tests/test_rhymes.py
@@ -1,3 +1,5 @@
+import _bootstrap  # noqa: F401
+
 from poetry_assistant.rhymes import RhymeAssistant
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,5 @@
+import _bootstrap  # noqa: F401
+
 from poetry_assistant.search import SearchEngine, SearchOptions
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -36,7 +36,7 @@ def test_rhyme_search_with_large_syllable_request(sample_db):
 
 def test_syllable_pattern_exact(sample_db):
     engine = SearchEngine(sample_db)
-    options = SearchOptions(pattern="[S P]-AY1/0{1} D-ER0/0{0}", pattern_type="syllable", limit=10)
+    options = SearchOptions(pattern="[S P]-AY[1] D-ER[0]", pattern_type="syllable", limit=10)
     results = engine.search(options)
     assert [result.word for result in results] == ["spider"]
     assert results[0].matched_syllables == (0, 2)
@@ -44,7 +44,7 @@ def test_syllable_pattern_exact(sample_db):
 
 def test_syllable_pattern_contains(sample_db):
     engine = SearchEngine(sample_db)
-    options = SearchOptions(pattern="*-AW1/*{1}", pattern_type="syllable", contains=True, limit=10)
+    options = SearchOptions(pattern="*-AW[1]/*", pattern_type="syllable", contains=True, limit=10)
     results = engine.search(options)
     words = [result.word for result in results]
     assert "about" in words
@@ -54,9 +54,9 @@ def test_syllable_pattern_contains(sample_db):
 
 def test_syllable_pattern_ignore_stress(sample_db):
     engine = SearchEngine(sample_db)
-    strict = SearchOptions(pattern="D-ER*/0{1}", pattern_type="syllable", contains=True, limit=10)
+    strict = SearchOptions(pattern="D-ER*[1]", pattern_type="syllable", contains=True, limit=10)
     relaxed = SearchOptions(
-        pattern="D-ER*/0{1}",
+        pattern="D-ER*[1]",
         pattern_type="syllable",
         contains=True,
         ignore_stress=True,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -66,3 +66,23 @@ def test_syllable_pattern_ignore_stress(sample_db):
     relaxed_results = engine.search(relaxed)
     assert all(result.word != "spider" for result in strict_results)
     assert any(result.word == "spider" for result in relaxed_results)
+
+
+def test_three_syllable_vowel_options(sample_db):
+    # add entries that exercise multi-option vowel matching with explicit stress blocks
+    heavenly = sample_db.add_word("heavenly")
+    sample_db.add_pronunciation(heavenly, "HH EH1 V AH0 N L IY0".split())
+    seventeen = sample_db.add_word("seventeen")
+    sample_db.add_pronunciation(seventeen, "S EH1 V AH0 N T IY1 N".split())
+    memory = sample_db.add_word("memory")
+    sample_db.add_pronunciation(memory, "M EH1 M ER0 IY0".split())
+
+    engine = SearchEngine(sample_db)
+    options = SearchOptions(
+        pattern="*-EH[12]/* *-(AH|ER)[0]/* *-IY[012]/*",
+        pattern_type="syllable",
+        limit=10,
+    )
+    results = engine.search(options)
+    words = {result.word for result in results}
+    assert {"heavenly", "seventeen", "memory"}.issubset(words)

--- a/tests/test_syllables.py
+++ b/tests/test_syllables.py
@@ -66,3 +66,11 @@ def test_multi_letter_phonemes_match_with_wildcards():
     single_onset_pattern = parse_syllable_pattern("?-AA1/(R M)")
     assert matches_syllable_pattern(thrown, pattern_second_r)
     assert matches_syllable_pattern(charm, single_onset_pattern)
+
+
+def test_vowel_alternatives_match_multiple_words():
+    pattern = parse_syllable_pattern("*-EH/*{1} *-(AH|ER)/*{0} *-AE/P{1}")
+    clever_rap = syllabify("K L EH1 V ER0 R AE1 P")
+    mend_the_gap = syllabify("M EH1 N D DH AH0 G AE1 P")
+    assert matches_syllable_pattern(clever_rap, pattern)
+    assert matches_syllable_pattern(mend_the_gap, pattern)

--- a/tests/test_syllables.py
+++ b/tests/test_syllables.py
@@ -1,0 +1,68 @@
+from poetry_assistant.syllables import (
+    find_syllable_matches,
+    matches_syllable_pattern,
+    parse_syllable_pattern,
+    syllabify,
+)
+
+
+def test_syllabify_breaks_into_syllables():
+    syllables = syllabify("S P AY1 D ER0")
+    assert len(syllables) == 2
+    first, second = syllables
+    assert first.onset == ("S", "P")
+    assert first.nucleus == "AY1"
+    assert first.coda == ()
+    assert second.onset == ("D",)
+    assert second.nucleus == "ER0"
+    assert second.coda == ()
+
+
+def test_pattern_matching_exact_sequence():
+    syllables = syllabify("S P AY1 D ER0")
+    pattern = parse_syllable_pattern("[S P]-AY1/0{1} D-ER0/0{0}")
+    matches = find_syllable_matches(syllables, pattern)
+    assert matches == [(0, 2)]
+
+
+def test_pattern_matching_with_contains():
+    syllables = syllabify("AH0 B AW1 T")
+    pattern = parse_syllable_pattern("*-AW1/*{1}")
+    matches = find_syllable_matches(syllables, pattern, contains=True)
+    assert matches == [(1, 2)]
+
+
+def test_ignore_stress_allows_mismatch():
+    syllables = syllabify("S P AY1 D ER0")
+    pattern = parse_syllable_pattern("D-ER*/0{1}")
+    assert not matches_syllable_pattern(syllables, pattern, contains=True)
+    assert matches_syllable_pattern(syllables, pattern, contains=True, ignore_stress=True)
+
+
+def test_question_mark_requires_single_onset_phoneme():
+    single_consonant = syllabify("G AW1 N")
+    double_consonant = syllabify("B R AW1 N")
+    pattern = parse_syllable_pattern("?-AW1/N")
+    assert matches_syllable_pattern(single_consonant, pattern)
+    assert not matches_syllable_pattern(double_consonant, pattern)
+
+
+def test_second_consonant_can_be_constrained():
+    pattern = parse_syllable_pattern("(* R)-AW1/N")
+    brown = syllabify("B R AW1 N")
+    drown = syllabify("D R AW1 N")
+    gown = syllabify("G AW1 N")
+    clown = syllabify("K L AW1 N")
+    assert matches_syllable_pattern(brown, pattern)
+    assert matches_syllable_pattern(drown, pattern)
+    assert not matches_syllable_pattern(gown, pattern)
+    assert not matches_syllable_pattern(clown, pattern)
+
+
+def test_multi_letter_phonemes_match_with_wildcards():
+    thrown = syllabify("TH R OW1 N")
+    charm = syllabify("CH AA1 R M")
+    pattern_second_r = parse_syllable_pattern("(* R)-OW1/N")
+    single_onset_pattern = parse_syllable_pattern("?-AA1/(R M)")
+    assert matches_syllable_pattern(thrown, pattern_second_r)
+    assert matches_syllable_pattern(charm, single_onset_pattern)

--- a/tests/test_syllables.py
+++ b/tests/test_syllables.py
@@ -20,21 +20,21 @@ def test_syllabify_breaks_into_syllables():
 
 def test_pattern_matching_exact_sequence():
     syllables = syllabify("S P AY1 D ER0")
-    pattern = parse_syllable_pattern("[S P]-AY1/0{1} D-ER0/0{0}")
+    pattern = parse_syllable_pattern("[S P]-AY[1] D-ER[0]")
     matches = find_syllable_matches(syllables, pattern)
     assert matches == [(0, 2)]
 
 
 def test_pattern_matching_with_contains():
     syllables = syllabify("AH0 B AW1 T")
-    pattern = parse_syllable_pattern("*-AW1/*{1}")
+    pattern = parse_syllable_pattern("*-AW[1]/*")
     matches = find_syllable_matches(syllables, pattern, contains=True)
     assert matches == [(1, 2)]
 
 
 def test_ignore_stress_allows_mismatch():
     syllables = syllabify("S P AY1 D ER0")
-    pattern = parse_syllable_pattern("D-ER*/0{1}")
+    pattern = parse_syllable_pattern("D-ER*[1]")
     assert not matches_syllable_pattern(syllables, pattern, contains=True)
     assert matches_syllable_pattern(syllables, pattern, contains=True, ignore_stress=True)
 
@@ -42,13 +42,13 @@ def test_ignore_stress_allows_mismatch():
 def test_question_mark_requires_single_onset_phoneme():
     single_consonant = syllabify("G AW1 N")
     double_consonant = syllabify("B R AW1 N")
-    pattern = parse_syllable_pattern("?-AW1/N")
+    pattern = parse_syllable_pattern("?-AW[1]/N")
     assert matches_syllable_pattern(single_consonant, pattern)
     assert not matches_syllable_pattern(double_consonant, pattern)
 
 
 def test_second_consonant_can_be_constrained():
-    pattern = parse_syllable_pattern("(* R)-AW1/N")
+    pattern = parse_syllable_pattern("(* R)-AW[1]/N")
     brown = syllabify("B R AW1 N")
     drown = syllabify("D R AW1 N")
     gown = syllabify("G AW1 N")
@@ -62,14 +62,14 @@ def test_second_consonant_can_be_constrained():
 def test_multi_letter_phonemes_match_with_wildcards():
     thrown = syllabify("TH R OW1 N")
     charm = syllabify("CH AA1 R M")
-    pattern_second_r = parse_syllable_pattern("(* R)-OW1/N")
-    single_onset_pattern = parse_syllable_pattern("?-AA1/(R M)")
+    pattern_second_r = parse_syllable_pattern("(* R)-OW[1]/N")
+    single_onset_pattern = parse_syllable_pattern("?-AA[1]/(R M)")
     assert matches_syllable_pattern(thrown, pattern_second_r)
     assert matches_syllable_pattern(charm, single_onset_pattern)
 
 
 def test_vowel_alternatives_match_multiple_words():
-    pattern = parse_syllable_pattern("*-EH/*{1} *-(AH|ER)/*{0} *-AE/P{1}")
+    pattern = parse_syllable_pattern("*-EH[1]/* *-[AH|ER][0]/* *-AE[1]/P")
     clever_rap = syllabify("K L EH1 V ER0 R AE1 P")
     mend_the_gap = syllabify("M EH1 N D DH AH0 G AE1 P")
     assert matches_syllable_pattern(clever_rap, pattern)

--- a/tests/test_syllables.py
+++ b/tests/test_syllables.py
@@ -1,3 +1,5 @@
+import _bootstrap  # noqa: F401
+
 from poetry_assistant.syllables import (
     find_syllable_matches,
     matches_syllable_pattern,


### PR DESCRIPTION
## Summary
- implement syllable segmentation, pattern parsing, and matching utilities for multi-syllable rhyme searches
- extend the search engine, CLI, and result formatting to handle syllable-pattern queries with optional stress ignoring
- document the new workflow and phoneme inventory, and add focused tests plus a planning document
- redesign onset and coda pattern matching to operate on phoneme tokens, enabling positional wildcards and multi-letter phoneme support with refreshed tests and docs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd8de2a8a08333870894f6195e2e0e