### PR TITLE
feat: expand syllable search flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Key options:
 * `--max-distance` / `--min-similarity` – enable near-match scoring by phoneme edit distance.
 * `--stress` – wildcard mask over stress digits (e.g. `1*0` to require stressed then unstressed syllables).
 * `--ignore-syllable-stress` – ignore stress differences when evaluating syllable patterns.
+* `--all` – list every matching result instead of truncating to the `--limit` value.
 * `--pos`, `--definition`, `--synonym` – filter by lexical metadata from WordNet.
 
-Results include each word’s pronunciation, stress signature, similarity score (if applicable), the syllable range that matched (for syllable searches), and the first matching definition. See `docs/syllable_pattern_guide.md` for the full pattern syntax and examples.
+Results include each word’s pronunciation, stress signature, similarity score (if applicable), the syllable range that matched (for syllable searches), and the first matching definition. Results are ordered from the highest syllable count down, breaking ties with the best match scores. See `docs/syllable_pattern_guide.md` for the full pattern syntax and examples.
 
 ## Rhyming with entire lines
 

--- a/docs/syllable_pattern_guide.md
+++ b/docs/syllable_pattern_guide.md
@@ -49,6 +49,19 @@ This pattern matches the pronunciation of “spider”.
   sequence in `[]` or `()`, or use `_`, `.` or `+` as separators. For example,
   `[K R]-OW[1]` and `K_R-OW[1]` both specify an onset of `K R`.
 
+### Whole-syllable wildcards
+
+* Use `*` as its own token to match any single syllable, regardless of onset,
+  vowel, coda, or stress.
+* Use `**` as its own token to match zero or more syllables. Combine with other
+  tokens to anchor the pattern at the start or end of a word.
+* Examples:
+  * `* *-AH[0]/* *-AH[0]/S` – matches three-syllable words whose last two
+    syllables rhyme with unstressed `AH` vowels ending in `S` (e.g., **bahas** in
+    the sample data).
+  * `** *-AH[0]/S` – matches any word ending in an unstressed `AH` vowel with an
+    `S` coda, regardless of the number of preceding syllables.
+
 ### Vowel alternatives
 
 * Provide multiple vowel options by separating them with `|`, commas, or
@@ -108,6 +121,8 @@ poetry-assistant search "[S P]-AY[1] D-ER[0]" --type syllable
 poetry-assistant search "*-AW[1]/*" --type syllable --contains
 poetry-assistant search "D-ER*[1]" --type syllable --contains --ignore-syllable-stress
 poetry-assistant search "*-EH[12]/* *-(AH|ER)[0]/* *-IY[012]/*" --type syllable
+poetry-assistant search "* *-AH[0]/* *-AH[0]/S" --type syllable
+poetry-assistant search "** *-AH[0]/* *-AH[0]/S" --type syllable
 ```
 
 The tabulated output shows the syllable range that satisfied the pattern in the

--- a/src/poetry_assistant/cli.py
+++ b/src/poetry_assistant/cli.py
@@ -102,6 +102,11 @@ def main(argv: Optional[list[str]] = None) -> None:
     search_parser.add_argument("--definition", help="Search for words whose definition contains this text")
     search_parser.add_argument("--synonym", help="Search using synonym text")
     search_parser.add_argument("--limit", type=int, default=25, help="Maximum number of results")
+    search_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Show all matching results (overrides --limit)",
+    )
 
     word_parser = subparsers.add_parser(
         "word", parents=[common], help="Show pronunciations and definitions for a word"
@@ -154,7 +159,7 @@ def main(argv: Optional[list[str]] = None) -> None:
             part_of_speech=args.pos,
             definition_query=args.definition,
             synonym_query=args.synonym,
-            limit=args.limit,
+            limit=None if getattr(args, "all", False) else args.limit,
         )
         engine = SearchEngine(db)
         results = engine.search(options)

--- a/src/poetry_assistant/rhymes.py
+++ b/src/poetry_assistant/rhymes.py
@@ -63,7 +63,7 @@ class RhymeAssistant:
                     formatted = _format_match(match)
                     if len(results[syllables]) < max_results:
                         results[syllables].append(formatted)
-        return dict(sorted(results.items()))
+        return dict(sorted(results.items(), reverse=True))
 
     def _line_pronunciations(self, line: str) -> List[Tuple[str, Pronunciation]]:
         words = WORD_RE.findall(line.lower())

--- a/src/poetry_assistant/syllables.py
+++ b/src/poetry_assistant/syllables.py
@@ -303,7 +303,12 @@ def find_syllable_matches(
         token = pattern[index]
         results: List[int] = []
         if isinstance(token, WildcardSequence):
-            for next_start in range(start, len(syllables) + 1):
+            # Allow the wildcard sequence to consume zero syllables before
+            # exploring longer spans. This preserves the intended "zero or
+            # more" semantics without requiring callers to add an explicit
+            # single-syllable wildcard to cover the empty case.
+            results.extend(_match(start, index + 1))
+            for next_start in range(start + 1, len(syllables) + 1):
                 results.extend(_match(next_start, index + 1))
             return tuple(dict.fromkeys(results))
         if start >= len(syllables):

--- a/tests/test_rhymes.py
+++ b/tests/test_rhymes.py
@@ -7,6 +7,8 @@ def test_rhyme_assistant(sample_db):
     assistant = RhymeAssistant(sample_db)
     line = "The curious cat"
     results = assistant.suggest_rhymes(line, max_syllables=2, max_results=5)
+    keys = list(results.keys())
+    assert keys == sorted(keys, reverse=True)
     assert 1 in results
     assert any("bat" in suggestion for suggestion in results[1])
 

--- a/tests/test_syllables.py
+++ b/tests/test_syllables.py
@@ -97,3 +97,12 @@ def test_double_wildcard_spans_variable_prefix():
     syllables = syllabify("AH0 B AW1 T")
     pattern = parse_syllable_pattern("** *-AW[1]/T")
     assert matches_syllable_pattern(syllables, pattern)
+
+
+def test_double_wildcard_allows_zero_length_match():
+    syllables = syllabify("AH0 S")
+    pattern = parse_syllable_pattern("** *-AH[0]/S")
+    assert find_syllable_matches(syllables, pattern) == [(0, 1)]
+
+    zero_only = find_syllable_matches(syllables, parse_syllable_pattern("**"), contains=True)
+    assert (1, 1) in zero_only

--- a/tests/test_syllables.py
+++ b/tests/test_syllables.py
@@ -1,6 +1,8 @@
 import _bootstrap  # noqa: F401
 
 from poetry_assistant.syllables import (
+    WildcardSequence,
+    WildcardSyllable,
     find_syllable_matches,
     matches_syllable_pattern,
     parse_syllable_pattern,
@@ -76,3 +78,22 @@ def test_vowel_alternatives_match_multiple_words():
     mend_the_gap = syllabify("M EH1 N D DH AH0 G AE1 P")
     assert matches_syllable_pattern(clever_rap, pattern)
     assert matches_syllable_pattern(mend_the_gap, pattern)
+
+
+def test_full_syllable_wildcard_and_sequence_tokens():
+    pattern = parse_syllable_pattern("* **")
+    assert isinstance(pattern[0], WildcardSyllable)
+    assert isinstance(pattern[1], WildcardSequence)
+
+
+def test_single_syllable_wildcard_matches_any_syllable():
+    syllables = syllabify("B AH0 T AH0 K AH0 S")
+    pattern = parse_syllable_pattern("* *-AH[0]/* *-AH[0]/S")
+    matches = find_syllable_matches(syllables, pattern)
+    assert matches == [(0, 3)]
+
+
+def test_double_wildcard_spans_variable_prefix():
+    syllables = syllabify("AH0 B AW1 T")
+    pattern = parse_syllable_pattern("** *-AW[1]/T")
+    assert matches_syllable_pattern(syllables, pattern)


### PR DESCRIPTION
## Summary
- support single- and multi-syllable wildcards for syllable searches and order results by syllable count and match score
- add a `--all` CLI flag to list every search result and document the updated behaviours
- ensure rhyme suggestions follow the new ordering and add tests for the new pattern semantics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f2b017fb9c83338418b514cb8abf74