### PR TITLE
feat: add perfect rhyme CLI search

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `poetry-assistant` executable exposes the following subcommands:
 * `search` – query the lexicon for phoneme, syllable, rhyme, or lexical matches.
 * `word` – inspect every stored pronunciation, stress pattern, and definition for a given word.
 * `rhymes-with` – analyse the end of a line and propose rhyme candidates for the trailing syllables.
+* `perfect-rhyme` – list words that share the final stressed syllable (vowel plus coda) and every trailing syllable exactly.
 
 ## Building the database
 
@@ -75,6 +76,14 @@ poetry-assistant rhymes-with "I wrote a clever rap" --max-syllables 3
 ```
 
 The assistant tokenises the final words of the line, retrieves pronunciations, and returns rhyme suggestions for the last one through N syllables. Near-rhyme parameters (`--max-distance`, `--min-similarity`, `--pos`) mirror the search command.
+
+## Finding perfect rhymes
+
+```bash
+poetry-assistant perfect-rhyme amazing
+```
+
+The perfect rhyme search starts at the final stressed syllable of each pronunciation for the target word. The vowel and coda of that syllable must match, and every subsequent syllable (including onsets) must match exactly, yielding textbook perfect rhymes.
 
 ## Inspecting individual entries
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ poetry-assistant rhymes-with "I wrote a clever rap" --max-syllables 3
 ```
 
 The assistant tokenises the final words of the line, retrieves pronunciations, and returns rhyme suggestions for the last one through N syllables. Near-rhyme parameters (`--max-distance`, `--min-similarity`, `--pos`) mirror the search command.
+Pass `--all` to list every rhyme candidate for each syllable count instead of respecting the per-group `--limit`.
 
 ## Finding perfect rhymes
 
@@ -84,6 +85,7 @@ poetry-assistant perfect-rhyme amazing
 ```
 
 The perfect rhyme search starts at the final stressed syllable of each pronunciation for the target word. The vowel and coda of that syllable must match, and every subsequent syllable (including onsets) must match exactly, yielding textbook perfect rhymes.
+Use `--all` to disable the per-pronunciation limit and show every matching word.
 
 ## Inspecting individual entries
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The perfect rhyme search starts at the final stressed syllable of each pronuncia
 poetry-assistant word serendipity
 ```
 
-Displays all pronunciations along with syllable counts, stress patterns, and the associated definitions and synonyms.
+Displays all pronunciations along with syllable counts, stress patterns, a syllabified breakdown of each pronunciation, and the associated definitions and synonyms.
 
 ## Frequently asked questions
 

--- a/src/poetry_assistant/cli.py
+++ b/src/poetry_assistant/cli.py
@@ -268,12 +268,7 @@ def _print_results(results: list[SearchResult]) -> None:
 
 
 def _format_cluster(cluster: Sequence[str]) -> str:
-    display_tokens: list[str] = []
-    for phoneme in cluster:
-        if phoneme == "NG":
-            display_tokens.extend(("N", "G"))
-        else:
-            display_tokens.append(phoneme)
+    display_tokens = list(cluster)
     if not display_tokens:
         return ""
     if len(display_tokens) == 1:

--- a/src/poetry_assistant/cli.py
+++ b/src/poetry_assistant/cli.py
@@ -205,11 +205,12 @@ def main(argv: Optional[list[str]] = None) -> None:
             min_similarity=args.min_similarity,
             part_of_speech=args.pos,
         )
-        for syllables, suggestions in results.items():
+        for syllables in sorted(results.keys(), reverse=True):
+            suggestions = results[syllables]
             print(f"Last {syllables} syllable(s):")
-            for suggestion in suggestions:
-                print(f"  {suggestion}")
-            if not suggestions:
+            if suggestions:
+                _print_results(suggestions)
+            else:
                 print("  (no matches)")
     elif args.command == "perfect-rhyme":
         assistant = RhymeAssistant(db)
@@ -225,8 +226,7 @@ def main(argv: Optional[list[str]] = None) -> None:
             for pronunciation, suggestions in matches.items():
                 print(f"Pronunciation {pronunciation}:")
                 if suggestions:
-                    for suggestion in suggestions:
-                        print(f"  {suggestion}")
+                    _print_results(suggestions)
                 else:
                     print("  (no matches)")
     db.close()

--- a/src/poetry_assistant/cli.py
+++ b/src/poetry_assistant/cli.py
@@ -123,6 +123,13 @@ def main(argv: Optional[list[str]] = None) -> None:
     rhyme_parser.add_argument("--pos", help="Part of speech filter for rhymes")
     rhyme_parser.add_argument("--limit", type=int, default=15, help="Maximum suggestions per syllable count")
 
+    perfect_parser = subparsers.add_parser(
+        "perfect-rhyme", parents=[common], help="Find words with perfect rhymes for the target word"
+    )
+    perfect_parser.add_argument("word", help="Target word to rhyme")
+    perfect_parser.add_argument("--pos", help="Part of speech filter for rhymes")
+    perfect_parser.add_argument("--limit", type=int, default=15, help="Maximum suggestions per pronunciation")
+
     args = parser.parse_args(argv)
 
     configure_logging(bool(getattr(args, "verbose", False)))
@@ -204,6 +211,24 @@ def main(argv: Optional[list[str]] = None) -> None:
                 print(f"  {suggestion}")
             if not suggestions:
                 print("  (no matches)")
+    elif args.command == "perfect-rhyme":
+        assistant = RhymeAssistant(db)
+        matches = assistant.perfect_rhymes(
+            word=args.word,
+            max_results=args.limit,
+            part_of_speech=args.pos,
+        )
+        if not matches:
+            print(f"No perfect rhymes found for {args.word}")
+        else:
+            print(f"Perfect rhymes for {args.word}:")
+            for pronunciation, suggestions in matches.items():
+                print(f"Pronunciation {pronunciation}:")
+                if suggestions:
+                    for suggestion in suggestions:
+                        print(f"  {suggestion}")
+                else:
+                    print("  (no matches)")
     db.close()
 
 

--- a/src/poetry_assistant/cli.py
+++ b/src/poetry_assistant/cli.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 from .database import PoetryDatabase
 from .ingest import build_database
@@ -266,13 +266,28 @@ def _print_results(results: list[SearchResult]) -> None:
         print(json.dumps(dict(headers=headers, rows=rows), indent=2))
 
 
+
+def _format_cluster(cluster: Sequence[str]) -> str:
+    display_tokens: list[str] = []
+    for phoneme in cluster:
+        if phoneme == "NG":
+            display_tokens.extend(("N", "G"))
+        else:
+            display_tokens.append(phoneme)
+    if not display_tokens:
+        return ""
+    if len(display_tokens) == 1:
+        return display_tokens[0]
+    return f"({' '.join(display_tokens)})"
+
+
 def _describe_syllables(pronunciation: Pronunciation) -> str:
     syllables = syllabify(pronunciation.phonemes)
     parts: list[str] = []
     for syllable in syllables:
-        onset = syllable.onset_text or "-"
+        onset = _format_cluster(syllable.onset)
         vowel = strip_stress(syllable.vowel)
-        coda = syllable.coda_text or "-"
+        coda = _format_cluster(syllable.coda)
         parts.append(f"{onset}-{vowel}[{syllable.stress}]/{coda}")
     return " | ".join(parts)
 

--- a/src/poetry_assistant/cli.py
+++ b/src/poetry_assistant/cli.py
@@ -124,6 +124,11 @@ def main(argv: Optional[list[str]] = None) -> None:
     rhyme_parser.add_argument("--min-similarity", type=float, help="Minimum similarity score for near rhymes")
     rhyme_parser.add_argument("--pos", help="Part of speech filter for rhymes")
     rhyme_parser.add_argument("--limit", type=int, default=15, help="Maximum suggestions per syllable count")
+    rhyme_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Show all matching rhymes (overrides --limit)",
+    )
 
     perfect_parser = subparsers.add_parser(
         "perfect-rhyme", parents=[common], help="Find words with perfect rhymes for the target word"
@@ -131,6 +136,11 @@ def main(argv: Optional[list[str]] = None) -> None:
     perfect_parser.add_argument("word", help="Target word to rhyme")
     perfect_parser.add_argument("--pos", help="Part of speech filter for rhymes")
     perfect_parser.add_argument("--limit", type=int, default=15, help="Maximum suggestions per pronunciation")
+    perfect_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Show all perfect rhymes (overrides --limit)",
+    )
 
     args = parser.parse_args(argv)
 
@@ -203,10 +213,11 @@ def main(argv: Optional[list[str]] = None) -> None:
                         print(base)
     elif args.command == "rhymes-with":
         assistant = RhymeAssistant(db)
+        limit = None if getattr(args, "all", False) else args.limit
         results = assistant.suggest_rhymes(
             line=args.line,
             max_syllables=args.max_syllables,
-            max_results=args.limit,
+            max_results=limit,
             max_distance=args.max_distance,
             min_similarity=args.min_similarity,
             part_of_speech=args.pos,
@@ -220,9 +231,10 @@ def main(argv: Optional[list[str]] = None) -> None:
                 print("  (no matches)")
     elif args.command == "perfect-rhyme":
         assistant = RhymeAssistant(db)
+        limit = None if getattr(args, "all", False) else args.limit
         matches = assistant.perfect_rhymes(
             word=args.word,
-            max_results=args.limit,
+            max_results=limit,
             part_of_speech=args.pos,
         )
         if not matches:

--- a/src/poetry_assistant/phonetics.py
+++ b/src/poetry_assistant/phonetics.py
@@ -64,16 +64,16 @@ class Pronunciation:
     def perfect_rhyme_key(self) -> Optional[str]:
         """Return substring covering the final stressed syllable and any trailing syllables."""
 
-        last_stressed: Optional[int] = None
+        last_primary: Optional[int] = None
         for index, phoneme in enumerate(self.phonemes):
             if not is_vowel(phoneme):
                 continue
             stress = phoneme[-1] if phoneme[-1].isdigit() else "0"
-            if stress in {"1", "2"}:
-                last_stressed = index
-        if last_stressed is None:
+            if stress == "1":
+                last_primary = index
+        if last_primary is None:
             return None
-        return " ".join(self.phonemes[last_stressed:])
+        return " ".join(self.phonemes[last_primary:])
 
     def terminal_vowels(self, syllables: int = 1) -> Optional[str]:
         """Return the vowel portion of the final syllables."""

--- a/src/poetry_assistant/phonetics.py
+++ b/src/poetry_assistant/phonetics.py
@@ -61,6 +61,20 @@ class Pronunciation:
         start = indices[-syllables]
         return " ".join(self.phonemes[start:])
 
+    def perfect_rhyme_key(self) -> Optional[str]:
+        """Return substring covering the final stressed syllable and any trailing syllables."""
+
+        last_stressed: Optional[int] = None
+        for index, phoneme in enumerate(self.phonemes):
+            if not is_vowel(phoneme):
+                continue
+            stress = phoneme[-1] if phoneme[-1].isdigit() else "0"
+            if stress in {"1", "2"}:
+                last_stressed = index
+        if last_stressed is None:
+            return None
+        return " ".join(self.phonemes[last_stressed:])
+
     def terminal_vowels(self, syllables: int = 1) -> Optional[str]:
         """Return the vowel portion of the final syllables."""
 

--- a/src/poetry_assistant/rhymes.py
+++ b/src/poetry_assistant/rhymes.py
@@ -28,7 +28,7 @@ class RhymeAssistant:
         self,
         line: str,
         max_syllables: int = 3,
-        max_results: int = 20,
+        max_results: Optional[int] = 20,
         max_distance: Optional[int] = None,
         min_similarity: Optional[float] = None,
         part_of_speech: Optional[str] = None,
@@ -61,14 +61,14 @@ class RhymeAssistant:
                     if key in seen:
                         continue
                     seen.add(key)
-                    if len(results[syllables]) < max_results:
+                    if max_results is None or len(results[syllables]) < max_results:
                         results[syllables].append(match)
         return dict(sorted(results.items(), reverse=True))
 
     def perfect_rhymes(
         self,
         word: str,
-        max_results: int = 25,
+        max_results: Optional[int] = 25,
         part_of_speech: Optional[str] = None,
     ) -> Dict[str, List[SearchResult]]:
         """Return perfect rhyme suggestions keyed by pronunciation."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,10 @@ def sample_db(tmp_path):
             "pronunciations": ["AH0 M EY1 Z IH0 NG"],
             "definitions": [("adjective", "causing great surprise", ["astonishing"])],
         },
+        "blazing": {
+            "pronunciations": ["B L EY1 Z IH0 NG"],
+            "definitions": [("adjective", "burning brightly", ["flaming"])],
+        },
     }
 
     for word, details in data.items():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,3 +62,10 @@ def test_default_database_path_uses_xdg_data_home(monkeypatch, tmp_path):
     resolved = cli._default_database_path()
     expected = tmp_path / "xdg" / "poetry_assistant" / "poetry_assistant.db"
     assert resolved == expected
+
+
+def test_word_command_prints_syllables(sample_db, capsys):
+    cli.main(["--database", str(sample_db.path), "word", "spider"])
+    captured = capsys.readouterr().out
+    assert "syllabified:" in captured
+    assert "S P-AY[1]/- | D-ER[0]/-" in captured

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,3 +75,43 @@ def test_word_command_formats_complex_clusters(sample_db, capsys):
     cli.main(["--database", str(sample_db.path), "word", "amazing"])
     captured = capsys.readouterr().out
     assert "-AH[0]/ | M-EY[1]/ | Z-IH[0]/NG" in captured
+
+
+def test_rhymes_with_all_disables_limit(monkeypatch, sample_db):
+    captured: dict[str, object] = {}
+
+    def fake_suggest(self, line, max_syllables=3, max_results=20, **kwargs):
+        captured["max_results"] = max_results
+        return {}
+
+    monkeypatch.setattr(cli.RhymeAssistant, "suggest_rhymes", fake_suggest)
+
+    cli.main([
+        "--database",
+        str(sample_db.path),
+        "rhymes-with",
+        "--all",
+        "The curious cat",
+    ])
+
+    assert captured.get("max_results") is None
+
+
+def test_perfect_rhyme_all_disables_limit(monkeypatch, sample_db):
+    captured: dict[str, object] = {}
+
+    def fake_perfect(self, word, max_results=25, **kwargs):
+        captured["max_results"] = max_results
+        return {}
+
+    monkeypatch.setattr(cli.RhymeAssistant, "perfect_rhymes", fake_perfect)
+
+    cli.main([
+        "--database",
+        str(sample_db.path),
+        "perfect-rhyme",
+        "--all",
+        "amazing",
+    ])
+
+    assert captured.get("max_results") is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,4 +68,10 @@ def test_word_command_prints_syllables(sample_db, capsys):
     cli.main(["--database", str(sample_db.path), "word", "spider"])
     captured = capsys.readouterr().out
     assert "syllabified:" in captured
-    assert "S P-AY[1]/- | D-ER[0]/-" in captured
+    assert "(S P)-AY[1]/ | D-ER[0]/" in captured
+
+
+def test_word_command_formats_complex_clusters(sample_db, capsys):
+    cli.main(["--database", str(sample_db.path), "word", "amazing"])
+    captured = capsys.readouterr().out
+    assert "-AH[0]/ | M-EY[1]/ | Z-IH[0]/(N G)" in captured

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,4 +74,4 @@ def test_word_command_prints_syllables(sample_db, capsys):
 def test_word_command_formats_complex_clusters(sample_db, capsys):
     cli.main(["--database", str(sample_db.path), "word", "amazing"])
     captured = capsys.readouterr().out
-    assert "-AH[0]/ | M-EY[1]/ | Z-IH[0]/(N G)" in captured
+    assert "-AH[0]/ | M-EY[1]/ | Z-IH[0]/NG" in captured

--- a/tests/test_phonetics.py
+++ b/tests/test_phonetics.py
@@ -14,6 +14,16 @@ def test_pronunciation_features():
     assert pron.terminal_consonants() == "T"
 
 
+def test_perfect_rhyme_key_uses_last_primary_stress():
+    pron = Pronunciation(("P", "AH1", "S", "T", "EY2", "SH", "AH0", "N"))
+    assert pron.perfect_rhyme_key() == "AH1 S T EY2 SH AH0 N"
+
+
+def test_perfect_rhyme_key_requires_primary_stress():
+    pron = Pronunciation(("B", "AH0", "T", "ER0", "F", "L", "AY2"))
+    assert pron.perfect_rhyme_key() is None
+
+
 def test_similarity_metrics():
     left = ["AE1", "T"]
     right = ["AE1", "D"]

--- a/tests/test_rhymes.py
+++ b/tests/test_rhymes.py
@@ -12,3 +12,12 @@ def test_rhyme_assistant(sample_db):
     assert 1 in results
     assert any("bat" in suggestion for suggestion in results[1])
 
+
+def test_perfect_rhyme(sample_db):
+    assistant = RhymeAssistant(sample_db)
+    suggestions = assistant.perfect_rhymes("amazing", max_results=5)
+    assert "AH0 M EY1 Z IH0 NG" in suggestions
+    matches = suggestions["AH0 M EY1 Z IH0 NG"]
+    assert any("blazing" in suggestion for suggestion in matches)
+    assert all("amazing" not in suggestion for suggestion in matches)
+

--- a/tests/test_rhymes.py
+++ b/tests/test_rhymes.py
@@ -10,7 +10,7 @@ def test_rhyme_assistant(sample_db):
     keys = list(results.keys())
     assert keys == sorted(keys, reverse=True)
     assert 1 in results
-    assert any("bat" in suggestion for suggestion in results[1])
+    assert any(match.word == "bat" for match in results[1])
 
 
 def test_perfect_rhyme(sample_db):
@@ -18,6 +18,6 @@ def test_perfect_rhyme(sample_db):
     suggestions = assistant.perfect_rhymes("amazing", max_results=5)
     assert "AH0 M EY1 Z IH0 NG" in suggestions
     matches = suggestions["AH0 M EY1 Z IH0 NG"]
-    assert any("blazing" in suggestion for suggestion in matches)
-    assert all("amazing" not in suggestion for suggestion in matches)
+    assert any(match.word == "blazing" for match in matches)
+    assert all(match.word != "amazing" for match in matches)
 

--- a/tests/test_rhymes.py
+++ b/tests/test_rhymes.py
@@ -21,3 +21,16 @@ def test_perfect_rhyme(sample_db):
     assert any(match.word == "blazing" for match in matches)
     assert all(match.word != "amazing" for match in matches)
 
+
+def test_rhyme_assistant_unbounded_results(sample_db):
+    assistant = RhymeAssistant(sample_db)
+    results = assistant.suggest_rhymes("The curious cat", max_results=None)
+    assert results
+    assert any(matches for matches in results.values())
+
+
+def test_perfect_rhyme_unbounded_results(sample_db):
+    assistant = RhymeAssistant(sample_db)
+    suggestions = assistant.perfect_rhymes("amazing", max_results=None)
+    assert suggestions["AH0 M EY1 Z IH0 NG"]
+


### PR DESCRIPTION
## Summary
- add a `perfect-rhyme` CLI subcommand that lists words sharing the final stressed syllable and trailing syllables
- compute perfect rhyme keys for pronunciations and expose a search helper to reuse when filtering results
- extend fixtures and tests to cover perfect rhyme suggestions and document the new command in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f338a617708333802c6bddb2fb261e